### PR TITLE
Update sbvr-parser and lf-to-abstract-sql to add support for concept types on term form fact types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Updated sbvr-parser and lf-to-abstract-sql to add support for concept types on term form fact types.
+
 v2.1.1
 
 * Fixed getting api key actor ids

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   "dependencies": {
     "@resin/abstract-sql-compiler": "^2.1.0",
     "@resin/abstract-sql-to-odata-schema": "^1.0.0",
-    "@resin/lf-to-abstract-sql": "~0.0.17",
+    "@resin/lf-to-abstract-sql": "~0.0.18",
     "@resin/odata-parser": "~0.1.10",
     "@resin/odata-to-abstract-sql": "~0.3.6",
-    "@resin/sbvr-parser": "~0.0.18",
+    "@resin/sbvr-parser": "~0.0.24",
     "@resin/sbvr-types": "^1.0.0",
     "bluebird": "^3.0.6",
     "bluebird-lru-cache": "^1.0.0",


### PR DESCRIPTION
Depends on https://github.com/resin-io-modules/lf-to-abstract-sql/pull/1
