### PR TITLE
Fixed a typo in unique constraint violation error message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed a typo in unique constraint violation error message.
+
 v3.3.0
 
 * Fixed unique constraint violation error message.

--- a/src/server/src/sbvr-api/sbvr-utils.coffee
+++ b/src/server/src/sbvr-api/sbvr-utils.coffee
@@ -66,7 +66,7 @@ prettifyConstraintError = (err, tableName) ->
 					# We know it's the right error type, so if matches exists just return a generic error message, since we have failed to get the info for a more specific one.
 					if !matches?
 						throw new db.UniqueConstraintError('Unique key constraint violated')
-			throw new db.UniqueConstraintError('"' + matches[1] + '" must be unique.'.replace(/-/g, '__') + '.')
+			throw new db.UniqueConstraintError('"' + matches[1] + '" must be unique'.replace(/-/g, '__') + '.')
 
 		if err instanceof db.ForeignKeyConstraintError
 			switch db.engine


### PR DESCRIPTION
Introduced in #27 
Resulted in an extra dot in the message:
```
"uuid" must be unique..
```
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>