### PR TITLE
Use `process.exit(1)` when exiting abnormally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Use `process.exit(1)` when exiting abnormally
 * Don't try to register the coffee-script loader if one already exists, it allows for using custom coffee-script loaders.
 
 v3.4.0

--- a/src/server/src/config-loader/config-loader.coffee
+++ b/src/server/src/config-loader/config-loader.coffee
@@ -180,7 +180,7 @@ exports.setup = (app) ->
 			loadConfig(config)
 		.catch (err) ->
 			console.error('Error loading application config', err, err.stack)
-			process.exit()
+			process.exit(1)
 
 	return {
 		loadConfig

--- a/src/server/src/database-layer/db.coffee
+++ b/src/server/src/database-layer/db.coffee
@@ -227,7 +227,7 @@ if pg?
 				pool.connect (err, client, done) ->
 					if err
 						console.error('Error connecting', err, err.stack)
-						process.exit()
+						process.exit(1)
 					tx = new PostgresTx(client, done, stackTraceErr)
 					if process.env.PG_SCHEMA?
 						tx.executeSql('SET search_path TO "' + process.env.PG_SCHEMA + '"')
@@ -297,7 +297,7 @@ if mysql?
 				_pool.getConnection (err, _db) ->
 					if err
 						console.error('Error connecting', err, err.stack)
-						process.exit()
+						process.exit(1)
 					_close = ->
 						_db.release()
 					tx = new MySqlTx(_db, _close, stackTraceErr)

--- a/src/server/src/sbvr-api/sbvr-utils.coffee
+++ b/src/server/src/sbvr-api/sbvr-utils.coffee
@@ -814,7 +814,7 @@ exports.setup = (app, _db, callback) ->
 		.catch (err) ->
 			tx.rollback()
 			console.error('Could not execute standard models', err, err.stack)
-			process.exit()
+			process.exit(1)
 	.then ->
 		db.executeSql('CREATE UNIQUE INDEX "uniq_model_model_type_vocab" ON "model" ("vocabulary", "model type");')
 		.catch -> # we can't use IF NOT EXISTS on all dbs, so we have to ignore the error raised if this index already exists

--- a/src/server/src/server-glue/module.coffee
+++ b/src/server/src/server-glue/module.coffee
@@ -69,6 +69,6 @@ init = (app, config) ->
 		Promise.all(promises)
 	.catch (err) ->
 		console.error('Error initialising server', err, err.stack)
-		process.exit()
+		process.exit(1)
 
 module.exports = { init, sbvrUtils, SessionStore: PinejsSessionStore }

--- a/src/server/src/server-glue/server.coffee
+++ b/src/server/src/server-glue/server.coffee
@@ -83,6 +83,6 @@ initialised = Pinejs.init(app)
 		console.info('Server started')
 .catch (err) ->
 	console.error('Error initialising server', err, err.stack)
-	process.exit()
+	process.exit(1)
 
 module.exports = { initialised, app, sbvrUtils }


### PR DESCRIPTION
Fixes https://github.com/resin-io/resin-api/issues/231