### PR TITLE
WIP: Allow filtering of roles during permission fetching

### DIFF
--- a/src/sbvr-api/permissions.coffee
+++ b/src/sbvr-api/permissions.coffee
@@ -180,7 +180,10 @@ exports.setup = (app, sbvrUtils) ->
 			throw err
 		.nodeify(callback)
 
-	exports.getUserPermissions = getUserPermissions = (userId, callback) ->
+	exports.getUserPermissions = getUserPermissions = (userId, roles, callback) ->
+		if typeof roles is 'function'
+			callback = roles
+			roles = null
 		if _.isString(userId)
 			userId = _.parseInt(userId)
 		if !_.isFinite(userId)
@@ -206,6 +209,14 @@ exports.setup = (app, sbvrUtils) ->
 								uhr: expiry_date: null
 							,	uhr: expiry_date: $gt: $now: null
 							]
+		if roles?
+			innerFilter = _.get(permsFilter, '$or.is_of__role.$any.$expr.rhp.role.$any.$expr')
+			newFilter =
+				$and: [
+					innerFilter,
+					r: name: $in: roles
+			]
+			_.set(permsFilter, '$or.is_of__role.$any.$expr.rhp.role.$any.$expr', newFilter)
 		return getPermissions(permsFilter, callback)
 
 	exports.getApiKeyPermissions = getApiKeyPermissions = do ->


### PR DESCRIPTION
This adds an optional external whitelist of roles available to a user.

We want to be able to restrict credentials (like a JWT), to only a given subset of the roles the user actually has and therefore only to the permissions associated with that given role.

Flowdock: https://www.flowdock.com/app/rulemotion/r-security/threads/6aoRkUtQ2XpwuPkwBu9rvnNrXb_

Change-Type: minor
Connects-To: #60

**This is untested so far, I just tested it by changing the js directly in the api node_modules.**