### PR TITLE
Some more minor fixes

### DIFF
--- a/src/sbvr-api/sbvr-utils.coffee
+++ b/src/sbvr-api/sbvr-utils.coffee
@@ -660,15 +660,20 @@ exports.handleODataRequest = handleODataRequest = (req, res, next) ->
 		# If we are dealing with a single request unpack the response and respond normally
 		if not (req.batch?.length > 0)
 
-			response = responses[0]
-			if response.status then res.status(response.status)
-			_.forEach response.headers, (headerValue, headerName) ->
+			[{ body, headers, status }] = responses
+			_.forEach headers, (headerValue, headerName) ->
 				res.set(headerName, headerValue)
 
-			if not response.body
-				res.send()
+			if not body
+				if status?
+					res.sendStatus(status)
+				else
+					console.error('No status or body set', req.url, responses)
+					res.sendStatus(500)
 			else
-				res.json(response.body)
+				if status?
+					res.status(status)
+				res.json(body)
 		# Otherwise its a multipart request and we reply with the appropriate multipart response
 		else
 			res.status(200).sendMulti(responses)


### PR DESCRIPTION
Here's a couple more minor fixes I found whilst testing in the api:
* Remove debug info
* Remove invalid extra arg
* Use `res.sendStatus` when there is no body to send the appropriate body for the status code

