### PR TITLE
Store api-key values in hashed format

### DIFF
--- a/migrations/7.0.0-migrate-api-keys.sql
+++ b/migrations/7.0.0-migrate-api-keys.sql
@@ -1,0 +1,3 @@
+CREATE EXTENSION pgcrypto;
+
+UPDATE "api key" SET "key" = 'SHA256:HEX:' || encode(digest("key", 'sha256'), 'hex') WHERE "key" NOT LIKE 'SHA256:HEX:%';

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@resin/odata-parser": "^0.2.5",
     "@resin/odata-to-abstract-sql": "^1.1.1",
     "@resin/sbvr-parser": "^0.1.0",
-    "@resin/sbvr-types": "^1.3.0",
+    "@resin/sbvr-types": "^1.4.0",
     "@types/bluebird": "3.5.16",
     "@types/body-parser": "1.16.8",
     "@types/compression": "0.0.35",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "memoizee": "^0.4.1",
     "ometa-js": "^1.4.2",
     "pinejs-client": "^4.3.2",
-    "sha.js": "^2.4.11",
     "typed-error": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "memoizee": "^0.4.1",
     "ometa-js": "^1.4.2",
     "pinejs-client": "^4.3.2",
+    "sha.js": "^2.4.11",
     "typed-error": "^2.0.0"
   },
   "devDependencies": {

--- a/src/sbvr-api/permissions.coffee
+++ b/src/sbvr-api/permissions.coffee
@@ -5,16 +5,8 @@ userModel = require './user.sbvr'
 { metadataEndpoints } = require './uri-parser'
 { BadRequestError, PermissionError, PermissionParsingError } = require './errors'
 { ODataParser } = require '@resin/odata-parser'
+sbvrTypes = require '@resin/sbvr-types'
 memoize = require 'memoizee'
-
-try
-	crypto = require('crypto')
-	hashFactory = ->
-		crypto.createHash('sha256')
-catch
-	shajs = require('sha.js')
-	hashFactory = ->
-		shajs('sha256')
 
 exports.PermissionError = PermissionError
 exports.PermissionParsingError = PermissionParsingError
@@ -56,11 +48,7 @@ parsePermissions = do ->
 			if value?.bind?
 				return { bind: value.bind + bindsLength }
 
-exports.hashApiKey = hashApiKey = (apiKey) ->
-	hash = hashFactory()
-	hash.update(apiKey)
-	hashValue = hash.digest('hex')
-	"SHA256:HEX:#{hashValue}"
+exports.hashApiKey = hashApiKey = sbvrTypes.SHA256.validateSync
 
 # Traverses all values in `check`, actions for the following data types:
 # string: Calls `stringCallback` and uses the value returned instead

--- a/src/sbvr-api/permissions.coffee
+++ b/src/sbvr-api/permissions.coffee
@@ -48,7 +48,7 @@ parsePermissions = do ->
 			if value?.bind?
 				return { bind: value.bind + bindsLength }
 
-exports.hashApiKey = hashApiKey = sbvrTypes.SHA256.validateSync
+exports.hashApiKey = hashApiKey = sbvrTypes.SHA.validateSync
 
 # Traverses all values in `check`, actions for the following data types:
 # string: Calls `stringCallback` and uses the value returned instead

--- a/src/sbvr-api/sbvr-utils.coffee
+++ b/src/sbvr-api/sbvr-utils.coffee
@@ -42,6 +42,8 @@ memoizedCompileRule = memoize(
 
 db = null
 
+exports.hashApiKey = permissions.hashApiKey
+
 exports.sbvrTypes = sbvrTypes
 
 fetchProcessing = _.mapValues sbvrTypes, ({ fetchProcessing }) ->

--- a/src/sbvr-api/user.sbvr
+++ b/src/sbvr-api/user.sbvr
@@ -7,7 +7,7 @@ Term:       password
 Term:       name
 	Concept Type: Text (Type)
 Term:       key
-	Concept Type: Short Text (Type)
+	Concept Type: SHA (Type)
 Term:       expiry date
 	Concept Type: Date Time (Type)
 Term:       description

--- a/src/sbvr-api/user.sbvr
+++ b/src/sbvr-api/user.sbvr
@@ -7,7 +7,7 @@ Term:       password
 Term:       name
 	Concept Type: Text (Type)
 Term:       key
-	Concept Type: SHA256 (Type)
+	Concept Type: SHA (Type)
 Term:       expiry date
 	Concept Type: Date Time (Type)
 Term:       description

--- a/src/sbvr-api/user.sbvr
+++ b/src/sbvr-api/user.sbvr
@@ -7,7 +7,7 @@ Term:       password
 Term:       name
 	Concept Type: Text (Type)
 Term:       key
-	Concept Type: SHA (Type)
+	Concept Type: SHA256 (Type)
 Term:       expiry date
 	Concept Type: Date Time (Type)
 Term:       description


### PR DESCRIPTION
This stores the api key values as sha256 hashes. The database values are prefixed with 'SHA256:HEX:' to indicate, which hash algorithm and which encoding are used.

Depends-On: https://github.com/resin-io-modules/sbvr-types/pull/14
Change-Type: major
Signed-off-by: Andreas Fitzek <andreas@resin.io>