### PR TITLE
Use the Engines enum for engines names to guarantee consistency

### DIFF
--- a/src/database-layer/db.ts
+++ b/src/database-layer/db.ts
@@ -7,6 +7,7 @@ import * as _ from 'lodash';
 import * as Promise from 'bluebird';
 import TypedError = require('typed-error');
 import * as env from '../config-loader/env';
+import { Engines } from '@resin/abstract-sql-compiler';
 
 export const metrics = new EventEmitter();
 
@@ -85,7 +86,7 @@ export type Database = {
 	ConstraintError: typeof ConstraintError;
 	UniqueConstraintError: typeof UniqueConstraintError;
 	ForeignKeyConstraintError: typeof ForeignKeyConstraintError;
-	engine: string;
+	engine: Engines;
 	executeSql: (
 		this: Database,
 		sql: Sql,
@@ -428,7 +429,7 @@ if (maybePg != null) {
 		}
 		return _.extend(
 			{
-				engine: 'postgres',
+				engine: Engines.postgres,
 				executeSql: atomicExecuteSql,
 				transaction: createTransaction(stackTraceErr =>
 					connect().then(client => {
@@ -525,7 +526,7 @@ if (maybeMysql != null) {
 
 		return _.extend(
 			{
-				engine: 'mysql',
+				engine: Engines.mysql,
 				executeSql: atomicExecuteSql,
 				transaction: createTransaction(stackTraceErr =>
 					connect().then(client => {
@@ -669,7 +670,7 @@ if (typeof window !== 'undefined' && window.openDatabase != null) {
 
 		return _.extend(
 			{
-				engine: 'websql',
+				engine: Engines.websql,
 				executeSql: atomicExecuteSql,
 				transaction: createTransaction(
 					stackTraceErr =>


### PR DESCRIPTION
The generated code is identical to before as the values were hardcoded to match for both (they're required to match), but this just lets typescript enforce that

Change-type: patch