### PR TITLE
11.x

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,7 +1,6 @@
 {
 	"*.ts": [
 		"prettier --config ./node_modules/resin-lint/config/.prettierrc --write",
-		"resin-lint --typescript --no-prettier",
-		"git add"
+		"resin-lint --typescript --no-prettier"
 	],
 }

--- a/circle.yml
+++ b/circle.yml
@@ -15,12 +15,6 @@ buildSteps: &buildSteps
         - ./node-*
 
 jobs:
-  node-6:
-    docker:
-      - image: circleci/node:6
-    working_directory: ~/node-6
-    steps: *buildSteps
-
   node-8:
     docker:
       - image: circleci/node:8
@@ -61,11 +55,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - node-6:
-          # Run for all tags (required to allow the deploy to trigger on version tags)
-          filters:
-            tags:
-              only: /.*/
       - node-8:
           # Run for all tags (required to allow the deploy to trigger on version tags)
           filters:
@@ -84,7 +73,6 @@ workflows:
       - deploy:
           # Deploy passing builds if they're tagged with a version
           requires:
-            - node-6
             - node-8
             - node-10
             - node-12

--- a/docs/CustomServerCode.md
+++ b/docs/CustomServerCode.md
@@ -12,7 +12,7 @@ This is an [express.js](http://expressjs.com/) app instance, and can be used to 
 ### sbvrUtils
 An entry point to the API internally to the server.
 
-#### runURI(method, uri, body = {}[, tx, req, callback])
+#### runURI(method, uri, body = {}[, tx, req])
 This allows making an API request internally that should match the result of making an equivalent http request to the API, and returns a promise.The request will be run with full privileges unless the `req` object is provided to instruct using a specified user.
 
 ##### tx
@@ -28,10 +28,10 @@ This is a subclass of the resin-platform-api class, which supports the additiona
 #### api
 This is an object containing keys of the api root and values that are an instance of PinejsClient for that api.  The PinejsClient instance also contains an additional `logger` property, which matches the interface of `console`, but which understands provided logging levels.
 
-#### executeModel(tx, model[, callback])
+#### executeModel(tx, model)
 This is an alias for executeModels for the case of a single model.
 
-#### executeModels(tx, models[, callback])
+#### executeModels(tx, models)
 Executes the given models and returns a promise.
 
 ##### tx
@@ -40,19 +40,13 @@ This should be an open transaction created with db.transaction
 ##### models
 This is an array which contains model objects, matching the model object of the config.json file.
 
-##### callback
-This is an (err, result) callback.
-
-#### deleteModel(vocabulary[, callback])
+#### deleteModel(vocabulary)
 Deletes the given vocabulary and returns a promise.
 
 ##### vocabulary
 The name of the vocabulary to delete.
 
-##### callback
-This is an (err, result) callback.
-
-#### runRule(vocab, rule[, callback])
+#### runRule(vocab, rule)
 Runs the given rule text against the vocabulary and returns a promise that resolves to any violators.
 
 ##### vocab
@@ -61,14 +55,11 @@ The vocabulary to run the rule against
 ##### rule
 This is a rule text, eg. Each pilot can fly at least 1 plane
 
-##### callback
-This is an (err, result) callback.
 
-
-#### getUserPermissions(userId[, callback])
+#### getUserPermissions(userId)
 This returns a promise that resolves to the user permissions for the given userId
 
-#### getApiKeyPermissions(apiKey[, callback])
+#### getApiKeyPermissions(apiKey)
 This returns a promise that resolves to the api key permissions for the given apiKey
 
 #### apiKeyMiddleware(req, res, next)
@@ -83,7 +74,7 @@ This is a default `customAuthorizationMiddleware`, which is useful to avoid havi
 #### customAuthorizationMiddleware(expectedScheme = 'Bearer')
 This is a function that will return a middleware that checks the `Authorization` header for a `scheme` that matches the `expectedScheme` and a token matching a valid api key and adds a `req.apiKey` entry `{ key, permissions }`. The middleware can also be called directly and will return a Promise that signifies completion.
 
-#### checkPermissions(req, permissionCheck, request[, callback])
+#### checkPermissions(req, permissionCheck, request)
 This checks that the currently logged in (or guest) user has the required permissions
 
 #### checkPermissionsMiddleware(permissionCheck)
@@ -92,7 +83,7 @@ This generates a middleware that will run the given permissionCheck
 #### handleODataRequest
 This is a middleware that will handle an OData request for `GET`/`PUT`/`POST`/`PATCH`/`MERGE`/`DELETE`
 
-#### executeStandardModels(tx[, callback])
+#### executeStandardModels(tx)
 This executes the built in models (dev, transaction, Auth) and returns a promise that resolves upon completion.
 
 #### addHook(method, apiRoot, resourceName, callbacks)
@@ -110,7 +101,7 @@ The name of the resource under the apiRoot to hook into, eg user
 ##### callbacks
 An object containing a key of the hook point and a value of the callback to call. See [Hooks documentation](./Hooks.md) for more
 
-#### setup(app, db[, callback])
+#### setup(app, db)
 This is called by the server, you should never need to use this.
 
 ### db
@@ -119,11 +110,8 @@ An object that allows direct connection to the database, which is similar to the
 #### engine
 A lowercase string that denotes the current database engine in use (possible values are currently: postgres, mysql, websql, and sqlite)
 
-#### executeSql(sql, bindings[, callback])
+#### executeSql(sql, bindings)
 This runs the given SQL statement in a transaction of it's own, with ? bindings replaced by the values in the bindings array and returns a promise.
-
-#### callback
-This has a signature of (err, result)
 
 #### transaction([callback])
 Returns a promise that will provide a `tx` object.
@@ -134,11 +122,8 @@ This callback is called with a `tx` object.
 ### tx
 This is created by a succesful call to `db.transaction`.
 
-#### executeSql(sql, bindings[, callback])
+#### executeSql(sql, bindings)
 This runs the given SQL statement in the context of the transaction it is called on, with ? bindings replaced by the values in the bindings array and returns a promise.
-
-#### callback
-This has a signature of (err, result)
 
 #### end()
 This ends/commits a transaction.
@@ -146,13 +131,10 @@ This ends/commits a transaction.
 #### rollback()
 This rolls back a transaction.
 
-#### tableList(extraWhereClause = ''[, callback])
+#### tableList(extraWhereClause = '')
 This returns a promise that resolves to a list of tables, the extraWhereClause can reference a "name" which will be the table's name.
 
-#### callback
-This has a signature of (err, result)
-
-#### dropTable(tableName, ifExists = true[, callback])
+#### dropTable(tableName, ifExists = true)
 This will drop the given table, returning a promise.
 
 #### tableName
@@ -160,9 +142,6 @@ The name of the table to drop.
 
 #### ifExists
 Whether to use an "IF EXISTS" clause or not.
-
-#### callback
-This has a signature of (err, result)
 
 ### result
 #### rows

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "grunt-ts": "^6.0.0-beta.22",
     "grunt-webpack": "^3.1.3",
     "husky": "^4.0.10",
-    "lint-staged": "^9.5.0",
+    "lint-staged": "^10.0.0",
     "load-grunt-tasks": "^5.1.0",
     "prettier": "^1.19.1",
     "raw-loader": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/method-override": "0.0.31",
     "@types/multer": "^1.3.10",
     "@types/mysql": "0.0.34",
-    "@types/node": "^6.14.9",
+    "@types/node": "^10.17.13",
     "@types/passport": "^0.4.7",
     "@types/passport-local": "1.0.33",
     "@types/passport-strategy": "^0.2.35",
@@ -83,7 +83,7 @@
     "resin-lint": "^2.0.1",
     "terser-webpack-plugin": "^1.4.3",
     "ts-loader": "^5.4.5",
-    "typescript": "^3.7.4",
+    "typescript": "^3.7.5",
     "umd-require-webpack-plugin": "0.0.1",
     "webpack": "^4.41.5",
     "webpack-dev-server": "^3.10.1"
@@ -105,8 +105,8 @@
     "ts-node": "^8.0.1"
   },
   "engines": {
-    "node": ">=6.0.0",
-    "npm": ">=5.0.0"
+    "node": ">=10.0.0",
+    "npm": ">=6.0.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@types/grunt": "^0.4.24",
-    "@types/terser-webpack-plugin": "^1.2.1",
+    "@types/terser-webpack-plugin": "^2.2.0",
     "@types/webpack": "^4.41.1",
     "coffee-loader": "^0.9.0",
     "grunt": "^1.0.4",
@@ -81,7 +81,7 @@
     "raw-loader": "^4.0.0",
     "require-npm4-to-publish": "^1.0.0",
     "resin-lint": "^2.0.1",
-    "terser-webpack-plugin": "^1.4.3",
+    "terser-webpack-plugin": "^2.3.2",
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.5",
     "umd-require-webpack-plugin": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lint-staged": "^9.5.0",
     "load-grunt-tasks": "^4.0.0",
     "prettier": "^1.19.1",
-    "raw-loader": "^2.0.0",
+    "raw-loader": "^4.0.0",
     "require-npm4-to-publish": "^1.0.0",
     "resin-lint": "^2.0.1",
     "terser-webpack-plugin": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "prettify": "prettier --config ./node_modules/resin-lint/config/.prettierrc --write \"{build,src,test,typings}/**/*.ts\" Gruntfile.ts"
   },
   "dependencies": {
-    "@resin/abstract-sql-compiler": "^6.11.1",
-    "@resin/lf-to-abstract-sql": "^2.2.0",
+    "@resin/abstract-sql-compiler": "^6.11.2",
+    "@resin/lf-to-abstract-sql": "^3.1.0",
     "@resin/odata-parser": "^1.3.0",
     "@resin/odata-to-abstract-sql": "^4.2.0",
     "@resin/sbvr-parser": "^0.2.6",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "require-npm4-to-publish": "^1.0.0",
     "resin-lint": "^2.0.1",
     "terser-webpack-plugin": "^1.4.3",
-    "ts-loader": "^5.4.5",
+    "ts-loader": "^6.2.1",
     "typescript": "^3.7.5",
     "umd-require-webpack-plugin": "0.0.1",
     "webpack": "^4.41.5",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "grunt-webpack": "^3.1.3",
     "husky": "^3.1.0",
     "lint-staged": "^9.5.0",
-    "load-grunt-tasks": "^4.0.0",
+    "load-grunt-tasks": "^5.1.0",
     "prettier": "^1.19.1",
     "raw-loader": "^4.0.0",
     "require-npm4-to-publish": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lodash": "^4.17.15",
     "memoizee": "^0.4.14",
     "pinejs-client-core": "^5.6.0",
-    "typed-error": "^2.0.0"
+    "typed-error": "^3.2.0"
   },
   "devDependencies": {
     "@types/grunt": "^0.4.24",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "grunt-text-replace": "^0.4.0",
     "grunt-ts": "^6.0.0-beta.22",
     "grunt-webpack": "^3.1.3",
-    "husky": "^3.1.0",
+    "husky": "^4.0.10",
     "lint-staged": "^9.5.0",
     "load-grunt-tasks": "^5.1.0",
     "prettier": "^1.19.1",

--- a/src/config-loader/config-loader.ts
+++ b/src/config-loader/config-loader.ts
@@ -23,19 +23,6 @@ export interface SetupFunction {
 		app: _express.Application,
 		sbvrUtilsInstance: typeof sbvrUtils,
 		db: Database,
-		done?: (err?: any) => void,
-	): PromiseLike<void>;
-	(
-		app: _express.Application,
-		sbvrUtilsInstance: typeof sbvrUtils,
-		db: Database,
-		done: (err?: any) => void,
-	): void;
-	(
-		app: _express.Application,
-		sbvrUtilsInstance: typeof sbvrUtils,
-		db: Database,
-		done?: (err?: any) => void,
 	): Resolvable<void>;
 }
 
@@ -239,24 +226,7 @@ export const setup = (app: _express.Application) => {
 									return;
 								}
 
-								return new Promise<void>((resolve, reject) => {
-									const promise = customCode(
-										app,
-										sbvrUtils,
-										sbvrUtils.db,
-										err => {
-											if (err) {
-												reject(err);
-											} else {
-												resolve();
-											}
-										},
-									);
-
-									if (Promise.is(promise)) {
-										resolve(promise);
-									}
-								});
+								return customCode(app, sbvrUtils, sbvrUtils.db);
 							}
 						}),
 					),

--- a/src/config-loader/config-loader.ts
+++ b/src/config-loader/config-loader.ts
@@ -338,7 +338,6 @@ export const setup = (app: _express.Application) => {
 			.catch(err => {
 				console.error('Error loading application config', err, err.stack);
 				process.exit(1);
-				throw new Error('Unreachable');
 			});
 	};
 

--- a/src/config-loader/config-loader.ts
+++ b/src/config-loader/config-loader.ts
@@ -9,7 +9,9 @@ const readFileAsync = (Promise.promisify(fs.readFile) as any) as (
 	filename: string,
 	encoding: string,
 ) => Promise<string>;
-const readdirAsync = Promise.promisify(fs.readdir);
+const readdirAsync = Promise.promisify(fs.readdir) as (
+	path: string,
+) => Promise<string[]>;
 
 import { Database } from '../database-layer/db';
 import * as sbvrUtils from '../sbvr-api/sbvr-utils';

--- a/src/data-server/SBVRServer.coffee
+++ b/src/data-server/SBVRServer.coffee
@@ -46,6 +46,12 @@ exports.config =
 		modelText: uiModel
 		apiRoot: 'ui'
 		customServerCode: exports
+		migrations: {
+			'11.0.0-modified-at': '''
+				ALTER TABLE "textarea"
+				ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+			'''
+		}
 	]
 exports.setup = (app, sbvrUtils, db) ->
 	uiApi = sbvrUtils.api.ui

--- a/src/database-layer/db.ts
+++ b/src/database-layer/db.ts
@@ -6,7 +6,7 @@ import * as _pgConnectionString from 'pg-connection-string';
 import * as EventEmitter from 'eventemitter3';
 import * as _ from 'lodash';
 import * as Promise from 'bluebird';
-import TypedError = require('typed-error');
+import { TypedError } from 'typed-error';
 import * as env from '../config-loader/env';
 import { Engines } from '@resin/abstract-sql-compiler';
 import { Resolvable } from '../sbvr-api/common-types';

--- a/src/extended-sbvr-parser/extended-sbvr-parser.ts
+++ b/src/extended-sbvr-parser/extended-sbvr-parser.ts
@@ -2,12 +2,9 @@ import { SBVRParser } from '@resin/sbvr-parser';
 // tslint:disable-next-line:no-var-requires
 const Types: string = require('@resin/sbvr-types/Type.sbvr');
 import { version as sbvrParserVersion } from '@resin/sbvr-parser/package.json';
-const {
-	version,
-}: // tslint:disable-next-line:no-var-requires
-{ version: string } = require('@resin/sbvr-parser/package.json');
+import { version } from '@resin/sbvr-parser/package.json';
 
-export = SBVRParser._extend({
+export const ExtendedSBVRParser = SBVRParser._extend({
 	initialize() {
 		SBVRParser.initialize.call(this);
 		this.AddCustomAttribute('Database ID Field:');

--- a/src/http-transactions/transactions.coffee
+++ b/src/http-transactions/transactions.coffee
@@ -7,6 +7,22 @@ exports.config =
 		apiRoot: 'transaction'
 		modelText: transactionModel
 		customServerCode: exports
+		migrations: {
+			'11.0.0-modified-at': '''
+				ALTER TABLE "conditional field"
+				ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+				ALTER TABLE "conditional resource"
+				ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+				ALTER TABLE "lock"
+				ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+				ALTER TABLE "resource"
+				ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+				ALTER TABLE "resource-is under-lock"
+				ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+				ALTER TABLE "transaction"
+				ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+			'''
+		}
 	]
 exports.setup = (app, sbvrUtils) ->
 	exports.addModelHooks = (modelName) ->

--- a/src/migrator/migrator.ts
+++ b/src/migrator/migrator.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as Promise from 'bluebird';
-import TypedError = require('typed-error');
+import { TypedError } from 'typed-error';
 // tslint:disable-next-line:no-var-requires
 const modelText: string = require('./migrations.sbvr');
 import { Tx } from '../database-layer/db';

--- a/src/migrator/migrator.ts
+++ b/src/migrator/migrator.ts
@@ -103,18 +103,23 @@ export const run = (tx: Tx, model: ApiRootModel): Promise<void> => {
 };
 
 const checkModelAlreadyExists = (tx: Tx, modelName: string): Promise<boolean> =>
-	tx
-		.executeSql(
-			binds`
+	tx.tableList("name = 'migration'").then(result => {
+		if (result.rows.length === 0) {
+			return false;
+		}
+		return tx
+			.executeSql(
+				binds`
 SELECT 1
 FROM "model"
 WHERE "model"."is of-vocabulary" = ${1}
 LIMIT 1`,
-			[modelName],
-		)
-		.then(({ rows }) => {
-			return rows.length > 0;
-		});
+				[modelName],
+			)
+			.then(({ rows }) => {
+				return rows.length > 0;
+			});
+	});
 
 const getExecutedMigrations = (tx: Tx, modelName: string): Promise<string[]> =>
 	tx
@@ -245,6 +250,12 @@ export const config: Config = {
 			modelName: 'migrations',
 			apiRoot: 'migrations',
 			modelText: modelText,
+			migrations: {
+				'11.0.0-modified-at': `
+					ALTER TABLE "migration"
+					ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+				`,
+			},
 		},
 	],
 };

--- a/src/odata-metadata/odata-metadata-generator.ts
+++ b/src/odata-metadata/odata-metadata-generator.ts
@@ -31,7 +31,7 @@ const forEachUniqueTable = <T>(
 	return result;
 };
 
-const odataMetadataGenerator = (
+export const generateODataMetadata = (
 	vocabulary: string,
 	abstractSqlModel: AbstractSqlModel,
 ) => {
@@ -175,5 +175,4 @@ const odataMetadataGenerator = (
 	);
 };
 
-odataMetadataGenerator.version = version;
-export = odataMetadataGenerator;
+generateODataMetadata.version = version;

--- a/src/pinejs-session-store/pinejs-session-store.ts
+++ b/src/pinejs-session-store/pinejs-session-store.ts
@@ -137,6 +137,12 @@ export = class PinejsSessionStore extends Store {
 					default: false,
 					error: true,
 				},
+				migrations: {
+					'11.0.0-modified-at': `
+						ALTER TABLE "session"
+						ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+					`,
+				},
 			},
 		],
 	};

--- a/src/pinejs-session-store/pinejs-session-store.ts
+++ b/src/pinejs-session-store/pinejs-session-store.ts
@@ -4,6 +4,8 @@ import * as permissions from '../sbvr-api/permissions';
 import { api, AnyObject } from '../sbvr-api/sbvr-utils';
 import { Config } from '../config-loader/config-loader';
 
+export { Store };
+
 const sessionModel = `
 	Vocabulary: session
 
@@ -27,7 +29,7 @@ const sessionModel = `
 		Necessity: Each session has at most 1 expiry time
 `;
 
-export = class PinejsSessionStore extends Store {
+export class PinejsSessionStore extends Store {
 	get = ((sid, callback) => {
 		api.session
 			.get({
@@ -146,4 +148,4 @@ export = class PinejsSessionStore extends Store {
 			},
 		],
 	};
-};
+}

--- a/src/sbvr-api/errors.ts
+++ b/src/sbvr-api/errors.ts
@@ -3,7 +3,6 @@ import { TypedError } from 'typed-error';
 export class PermissionError extends TypedError {}
 export class PermissionParsingError extends TypedError {}
 
-export class UnsupportedMethodError extends TypedError {}
 export class SqlCompilationError extends TypedError {}
 export class SbvrValidationError extends TypedError {}
 

--- a/src/sbvr-api/errors.ts
+++ b/src/sbvr-api/errors.ts
@@ -1,4 +1,4 @@
-import TypedError = require('typed-error');
+import { TypedError } from 'typed-error';
 
 export class PermissionError extends TypedError {}
 export class PermissionParsingError extends TypedError {}

--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -1208,8 +1208,34 @@ export const config = {
 			apiRoot: 'Auth',
 			modelText: userModel,
 			customServerCode: exports,
+			migrations: {
+				'11.0.0-modified-at': `
+					ALTER TABLE "actor"
+					ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+
+					ALTER TABLE "api key"
+					ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+					ALTER TABLE "api key-has-permission"
+					ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+					ALTER TABLE "api key-has-role"
+					ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+
+					ALTER TABLE "permission"
+					ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+
+					ALTER TABLE "role"
+					ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+
+					ALTER TABLE "user"
+					ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+					ALTER TABLE "user-has-role"
+					ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+					ALTER TABLE "user-has-permission"
+					ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+				`,
+			},
 		},
-	],
+	] as sbvrUtils.ExecutableModel[],
 };
 export const setup = () => {
 	sbvrUtils.addPureHook('all', 'all', 'all', {

--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -684,7 +684,6 @@ const getCheckPasswordQuery = _.once(() =>
 export const checkPassword = (
 	username: string,
 	password: string,
-	callback?: (err?: Error, permissions?: string[]) => void,
 ): Promise<{
 	id: number;
 	actor: number;
@@ -693,29 +692,27 @@ export const checkPassword = (
 }> =>
 	getCheckPasswordQuery()({
 		username,
-	})
-		.then((result: AnyObject[]) => {
-			if (result.length === 0) {
-				throw new Error('User not found');
+	}).then((result: AnyObject[]) => {
+		if (result.length === 0) {
+			throw new Error('User not found');
+		}
+		const hash = result[0].password;
+		const userId = result[0].id;
+		const actorId = result[0].actor;
+		return sbvrUtils.sbvrTypes.Hashed.compare(password, hash).then(res => {
+			if (!res) {
+				throw new Error('Passwords do not match');
 			}
-			const hash = result[0].password;
-			const userId = result[0].id;
-			const actorId = result[0].actor;
-			return sbvrUtils.sbvrTypes.Hashed.compare(password, hash).then(res => {
-				if (!res) {
-					throw new Error('Passwords do not match');
-				}
-				return getUserPermissions(userId).then(permissions => {
-					return {
-						id: userId,
-						actor: actorId,
-						username,
-						permissions,
-					};
-				});
+			return getUserPermissions(userId).then(permissions => {
+				return {
+					id: userId,
+					actor: actorId,
+					username,
+					permissions,
+				};
 			});
-		})
-		.asCallback(callback);
+		});
+	});
 
 const getUserPermissionsQuery = _.once(() =>
 	sbvrUtils.api.Auth.prepare<{ userId: number }>({
@@ -790,10 +787,7 @@ const getUserPermissionsQuery = _.once(() =>
 		},
 	}),
 );
-export const getUserPermissions = (
-	userId: number,
-	callback?: (err: Error | undefined, permissions: string[]) => void,
-): Promise<string[]> => {
+export const getUserPermissions = (userId: number): Promise<string[]> => {
 	if (_.isString(userId)) {
 		userId = _.parseInt(userId);
 	}
@@ -808,8 +802,7 @@ export const getUserPermissions = (
 		)
 		.tapCatch(err => {
 			sbvrUtils.api.Auth.logger.error('Error loading user permissions', err);
-		})
-		.asCallback(callback);
+		});
 };
 
 const getApiKeyPermissionsQuery = _.once(() =>
@@ -903,16 +896,13 @@ const $getApiKeyPermissions = memoize(
 	},
 );
 
-export const getApiKeyPermissions = (
-	apiKey: string,
-	callback?: (err: Error | undefined, permissions: string[]) => void,
-): Promise<string[]> =>
+export const getApiKeyPermissions = (apiKey: string): Promise<string[]> =>
 	Promise.try(() => {
 		if (!_.isString(apiKey)) {
 			throw new Error('API key has to be a string, got: ' + typeof apiKey);
 		}
 		return $getApiKeyPermissions(apiKey);
-	}).asCallback(callback);
+	});
 
 const getApiKeyActorIdQuery = _.once(() =>
 	sbvrUtils.api.Auth.prepare<{ apiKey: string }>({

--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -971,9 +971,6 @@ const checkApiKey = Promise.method((req: PermissionReq, apiKey: string) => {
 });
 
 export const customAuthorizationMiddleware = (expectedScheme = 'Bearer') => {
-	if (expectedScheme == null) {
-		expectedScheme = 'Bearer';
-	}
 	expectedScheme = expectedScheme.toLowerCase();
 	return (
 		req: express.Request,

--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -915,10 +915,6 @@ export const runURI = (
 	req?: permissions.PermissionReq,
 	custom?: AnyObject,
 ): Promise<PinejsClientCoreFactory.PromiseResultTypes> => {
-	if (body == null) {
-		body = {};
-	}
-
 	let user: User | undefined;
 	let apiKey: ApiKey | undefined;
 

--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -16,7 +16,7 @@ Promise.config({
 	cancellation: true,
 });
 
-import TypedError = require('typed-error');
+import { TypedError } from 'typed-error';
 import { cachedCompile } from './cached-compile';
 
 type LFModel = any[];

--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -1647,6 +1647,12 @@ export const executeStandardModels = (tx: _db.Tx): Promise<void> => {
 		logging: {
 			log: false,
 		},
+		migrations: {
+			'11.0.0-modified-at': `
+				ALTER TABLE "model"
+				ADD COLUMN IF NOT EXISTS "modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;
+			`,
+		},
 	})
 		.then(() => {
 			return executeModels(tx, permissions.config.models);

--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -52,7 +52,7 @@ import {
 	SbvrValidationError,
 	SqlCompilationError,
 	TranslationError,
-	UnsupportedMethodError,
+	MethodNotAllowedError,
 	BadRequestError,
 	HttpError,
 } from './errors';
@@ -1238,8 +1238,6 @@ const constructError = (
 		err instanceof PermissionParsingError
 	) {
 		return { status: 500 };
-	} else if (err instanceof UnsupportedMethodError) {
-		return { status: 405, body: err.message };
 	} else if (err instanceof HttpError) {
 		return { status: err.status, body: err.getResponseBody() };
 	} else if (err instanceof db.ConstraintError) {
@@ -1388,7 +1386,7 @@ const prepareResponse = (
 		case 'OPTIONS':
 			return respondOptions(req, res, request, result, tx);
 		default:
-			return Promise.reject(new UnsupportedMethodError());
+			return Promise.reject(new MethodNotAllowedError());
 	}
 };
 

--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -36,7 +36,7 @@ import deepFreeze = require('deep-freeze');
 import SBVRParser = require('../extended-sbvr-parser/extended-sbvr-parser');
 
 import * as migrator from '../migrator/migrator';
-import ODataMetadataGenerator = require('../odata-metadata/odata-metadata-generator');
+import { generateODataMetadata } from '../odata-metadata/odata-metadata-generator';
 
 // tslint:disable-next-line:no-var-requires
 const devModel = require('./dev.sbvr');
@@ -103,7 +103,7 @@ interface CompiledModel {
 	lf?: LFModel;
 	abstractSql: AbstractSQLCompiler.AbstractSqlModel;
 	sql: AbstractSQLCompiler.SqlModel;
-	odataMetadata: ReturnType<typeof ODataMetadataGenerator>;
+	odataMetadata: ReturnType<typeof generateODataMetadata>;
 }
 const models: {
 	[vocabulary: string]: CompiledModel;
@@ -427,9 +427,9 @@ export const generateModels = (
 
 	const odataMetadata = cachedCompile(
 		'metadata',
-		ODataMetadataGenerator.version,
+		generateODataMetadata.version,
 		{ vocab: vocab, abstractSqlModel: abstractSql },
-		() => ODataMetadataGenerator(vocab, abstractSql),
+		() => generateODataMetadata(vocab, abstractSql),
 	);
 
 	let sql: ReturnType<AbstractSQLCompiler.EngineInstance['compileSchema']>;

--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -33,7 +33,7 @@ import {
 } from '@resin/odata-to-abstract-sql';
 import deepFreeze = require('deep-freeze');
 
-import SBVRParser = require('../extended-sbvr-parser/extended-sbvr-parser');
+import { ExtendedSBVRParser } from '../extended-sbvr-parser/extended-sbvr-parser';
 
 import * as migrator from '../migrator/migrator';
 import { generateODataMetadata } from '../odata-metadata/odata-metadata-generator';
@@ -386,8 +386,8 @@ export const validateModel = (
 };
 
 export const generateLfModel = (seModel: string): LFModel =>
-	cachedCompile('lfModel', SBVRParser.version, seModel, () =>
-		SBVRParser.matchAll(seModel, 'Process'),
+	cachedCompile('lfModel', ExtendedSBVRParser.version, seModel, () =>
+		ExtendedSBVRParser.matchAll(seModel, 'Process'),
 	);
 
 export const generateAbstractSqlModel = (
@@ -743,7 +743,10 @@ export const runRule = (() => {
 			let abstractSqlModel: AbstractSQLCompiler.AbstractSqlModel;
 
 			try {
-				lfModel = SBVRParser.matchAll(seModel + '\nRule: ' + rule, 'Process');
+				lfModel = ExtendedSBVRParser.matchAll(
+					seModel + '\nRule: ' + rule,
+					'Process',
+				);
 			} catch (e) {
 				logger.error('Error parsing rule', rule, e);
 				throw new Error(`Error parsing rule'${rule}': ${e}`);

--- a/src/server-glue/module.ts
+++ b/src/server-glue/module.ts
@@ -68,5 +68,4 @@ export const init = (
 		.catch(err => {
 			console.error('Error initialising server', err, err.stack);
 			process.exit(1);
-			throw new Error('Unreachable');
 		});

--- a/src/server-glue/module.ts
+++ b/src/server-glue/module.ts
@@ -9,7 +9,7 @@ import * as configLoader from '../config-loader/config-loader';
 import * as migrator from '../migrator/migrator';
 
 import * as sbvrUtils from '../sbvr-api/sbvr-utils';
-import PinejsSessionStore = require('../pinejs-session-store/pinejs-session-store');
+import { PinejsSessionStore } from '../pinejs-session-store/pinejs-session-store';
 export { sbvrUtils, PinejsSessionStore };
 
 let databaseOptions: {

--- a/src/server-glue/server.ts
+++ b/src/server-glue/server.ts
@@ -14,7 +14,7 @@ import * as Promise from 'bluebird';
 import * as passportPinejs from '../passport-pinejs/passport-pinejs';
 
 import * as sbvrUtils from '../sbvr-api/sbvr-utils';
-import PinejsSessionStore = require('../pinejs-session-store/pinejs-session-store');
+import { PinejsSessionStore } from '../pinejs-session-store/pinejs-session-store';
 export { sbvrUtils, PinejsSessionStore };
 
 import * as express from 'express';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 		"rootDir": "src",
 		"sourceMap": true,
 		"strictNullChecks": true,
-		"target": "es2015",
+		"target": "es2018",
 		"declaration": true,
 		"skipLibCheck": true,
 		"resolveJsonModule": true


### PR DESCRIPTION
* Drop dual promise/callback based interfaces in favour of promise based
* Stop applying default for `null` in `runURI` and `customAuthorizationMiddleware`
    This matches standard javascript behavior for defaults
* Add an automatic "migrated at" field, with a required migration

Implements #263

