### PR TITLE
Fix missing `promise: true` option for memoized `$getApiKeyPermissions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prettify": "prettier --config ./node_modules/resin-lint/config/.prettierrc --write \"{build,src,test,typings}/**/*.ts\" Gruntfile.ts"
   },
   "dependencies": {
-    "@resin/abstract-sql-compiler": "^6.7.0",
+    "@resin/abstract-sql-compiler": "^6.7.1",
     "@resin/lf-to-abstract-sql": "^2.1.0",
     "@resin/odata-parser": "^1.2.0",
     "@resin/odata-to-abstract-sql": "^4.0.0",
@@ -34,7 +34,7 @@
     "@types/cookie-parser": "1.4.1",
     "@types/deep-freeze": "^0.1.1",
     "@types/express": "^4.17.0",
-    "@types/express-session": "^1.15.12",
+    "@types/express-session": "^1.15.13",
     "@types/lodash": "^4.14.134",
     "@types/memoizee": "0.4.2",
     "@types/method-override": "0.0.31",
@@ -54,13 +54,13 @@
     "express-session": "^1.16.2",
     "lodash": "^4.17.11",
     "memoizee": "^0.4.14",
-    "pinejs-client-core": "^5.5.1",
+    "pinejs-client-core": "^5.5.4",
     "typed-error": "^2.0.0"
   },
   "devDependencies": {
     "@types/grunt": "^0.4.24",
     "@types/terser-webpack-plugin": "^1.2.1",
-    "@types/webpack": "^4.4.32",
+    "@types/webpack": "^4.4.33",
     "coffee-loader": "^0.9.0",
     "grunt": "^1.0.4",
     "grunt-check-dependencies": "^1.0.0",
@@ -85,8 +85,8 @@
     "ts-loader": "^5.4.5",
     "typescript": "^3.5.2",
     "umd-require-webpack-plugin": "0.0.1",
-    "webpack": "^4.34.0",
-    "webpack-dev-server": "^3.7.1"
+    "webpack": "^4.35.0",
+    "webpack-dev-server": "^3.7.2"
   },
   "optionalDependencies": {
     "bcrypt": "^3.0.1",

--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -894,6 +894,7 @@ const $getApiKeyPermissions = memoize(
 			}),
 	{
 		primitive: true,
+		promise: true,
 		max: env.cache.apiKeys.max,
 		maxAge: env.cache.apiKeys.maxAge,
 	},


### PR DESCRIPTION
Update abstract-sql-compiler from 6.7.0 to 6.7.1
Update pinejs-client-core from 5.5.1 to 5.5.4

Change-type: patch