### PR TITLE
Stop sending `type` in the response as it's always an empty string

### DIFF
--- a/src/sbvr-api/odata-response.ts
+++ b/src/sbvr-api/odata-response.ts
@@ -143,7 +143,6 @@ export const process = (
 	const instances = rows.map(instance => {
 		instance.__metadata = {
 			uri: resourceURI(vocab, resourceName, instance[odataIdField]),
-			type: '',
 		};
 		return instance;
 	});


### PR DESCRIPTION
It provides no useful info and just increases gc, JSON.stringify, and
bandwidth costs

Change-type: patch