### PR TITLE
Don't generate a `resourceURI` if there is no resource id

### DIFF
--- a/src/sbvr-api/odata-response.ts
+++ b/src/sbvr-api/odata-response.ts
@@ -78,7 +78,10 @@ export const resourceURI = (
 	vocab: string,
 	resourceName: string,
 	id: string | number,
-) => {
+): string | undefined => {
+	if (id == null) {
+		return;
+	}
 	if (_.isString(id)) {
 		id = "'" + encodeURIComponent(id) + "'";
 	}

--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -1559,6 +1559,7 @@ const respondPost = (
 	return Promise.try(() => {
 		const onlyId = { d: [{ id }] };
 		if (
+			location == null ||
 			_.includes(
 				['0', 'false'],
 				_.get(request, ['odataQuery', 'options', 'returnResource']),


### PR DESCRIPTION
Change-type: patch