### PR TITLE
permissions: Set actor on api key

### DIFF
--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -175,11 +175,11 @@ apiHooks.MERGE = apiHooks.PATCH;
 
 export interface Actor {
 	permissions?: string[];
+	actor: number;
 }
 
 export interface User extends Actor {
 	id: number;
-	actor: number;
 }
 
 export interface ApiKey extends Actor {

--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -175,15 +175,16 @@ apiHooks.MERGE = apiHooks.PATCH;
 
 export interface Actor {
 	permissions?: string[];
-	actor: number;
 }
 
 export interface User extends Actor {
 	id: number;
+	actor: number;
 }
 
 export interface ApiKey extends Actor {
 	key: string;
+	actor?: number;
 }
 
 interface Response {


### PR DESCRIPTION
Invocation of actor ID lookup by api key is moved upstream,
so it can be stored on the apiKey object and reused.

This way, we can use actor ID in both session tokek and api key
authentication cases without extra DB query.

Change-type: minor
Signed-off-by: Roman Mazur <roman@balena.io>