### PR TITLE
✨: Add support for `canAccess()` function in permission.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@resin/abstract-sql-compiler": "^6.13.1",
     "@resin/lf-to-abstract-sql": "^3.1.1",
-    "@resin/odata-parser": "^1.3.1",
-    "@resin/odata-to-abstract-sql": "^4.3.0",
+    "@resin/odata-parser": "^1.4.0",
+    "@resin/odata-to-abstract-sql": "^4.4.0",
     "@resin/sbvr-parser": "^0.2.7",
     "@resin/sbvr-types": "^2.0.4",
     "@types/bluebird": "^3.5.29",


### PR DESCRIPTION
This will allow to write simpler permissions, which point
to access depending on other resources access.

Change-type: minor

Depends-On: https://github.com/balena-io-modules/odata-parser/pull/45
Depends-On: https://github.com/balena-io-modules/odata-to-abstract-sql/pull/48

Signed-off-by: Andreas Fitzek <andreas@balena.io>