### PR TITLE
Update dependencies

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,8 +1,0 @@
-{
-	"*.js": [
-		"balena-lint --typescript --fix"
-	],
-	"*.ts": [
-		"balena-lint --typescript --fix"
-	],
-}

--- a/package.json
+++ b/package.json
@@ -22,47 +22,47 @@
     "prettify": "balena-lint -e js -e ts --typescript --fix src build typings Gruntfile.ts"
   },
   "dependencies": {
-    "@balena/abstract-sql-compiler": "^7.0.3",
-    "@balena/lf-to-abstract-sql": "^4.1.0",
-    "@balena/odata-parser": "^2.2.0",
-    "@balena/odata-to-abstract-sql": "^5.3.0",
+    "@balena/abstract-sql-compiler": "^7.0.6",
+    "@balena/lf-to-abstract-sql": "^4.1.1",
+    "@balena/odata-parser": "^2.2.1",
+    "@balena/odata-to-abstract-sql": "^5.3.1",
     "@balena/sbvr-parser": "^1.1.1",
-    "@balena/sbvr-types": "^3.1.0",
-    "@types/bluebird": "^3.5.32",
+    "@balena/sbvr-types": "^3.1.2",
+    "@types/bluebird": "^3.5.33",
     "@types/body-parser": "^1.19.0",
     "@types/compression": "^1.7.0",
     "@types/cookie-parser": "^1.4.2",
     "@types/deep-freeze": "^0.1.2",
-    "@types/express": "^4.17.8",
-    "@types/express-session": "^1.17.0",
-    "@types/lodash": "^4.14.162",
-    "@types/memoizee": "^0.4.4",
+    "@types/express": "^4.17.9",
+    "@types/express-session": "^1.17.3",
+    "@types/lodash": "^4.14.165",
+    "@types/memoizee": "^0.4.5",
     "@types/method-override": "0.0.31",
     "@types/multer": "^1.4.4",
     "@types/mysql": "^2.15.15",
-    "@types/node": "^12.12.67",
+    "@types/node": "^12.19.8",
     "@types/passport": "^0.4.7",
     "@types/passport-local": "1.0.33",
     "@types/passport-strategy": "^0.2.35",
-    "@types/pg": "^7.14.5",
+    "@types/pg": "^7.14.7",
     "@types/randomstring": "^1.1.6",
     "@types/websql": "0.0.27",
     "bluebird": "^3.7.2",
-    "commander": "^6.1.0",
+    "commander": "^6.2.0",
     "deep-freeze": "0.0.1",
     "eventemitter3": "^4.0.7",
     "express-session": "^1.17.1",
     "lodash": "^4.17.20",
     "memoizee": "^0.4.14",
-    "pinejs-client-core": "^6.9.1",
+    "pinejs-client-core": "^6.9.3",
     "randomstring": "^1.1.5",
     "typed-error": "^3.2.1"
   },
   "devDependencies": {
-    "@balena/lint": "^5.2.1",
+    "@balena/lint": "^5.3.0",
     "@types/grunt": "^0.4.24",
     "@types/terser-webpack-plugin": "^4.2.0",
-    "@types/webpack": "^4.41.22",
+    "@types/webpack": "^4.41.25",
     "grunt": "^1.3.0",
     "grunt-check-dependencies": "^1.0.0",
     "grunt-cli": "^1.3.2",
@@ -75,14 +75,14 @@
     "grunt-ts": "^6.0.0-beta.22",
     "grunt-webpack": "^4.0.2",
     "husky": "^4.3.0",
-    "lint-staged": "^10.4.0",
+    "lint-staged": "^10.5.2",
     "load-grunt-tasks": "^5.1.0",
     "raw-loader": "^4.0.2",
     "require-npm4-to-publish": "^1.0.0",
     "terser-webpack-plugin": "^4.2.3",
-    "ts-loader": "^8.0.5",
+    "ts-loader": "^8.0.11",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.3",
+    "typescript": "^4.1.2",
     "webpack": "^4.44.2",
     "webpack-dev-server": "^3.11.0"
   },
@@ -97,8 +97,8 @@
     "mysql": "^2.18.1",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
-    "pg": "^8.3.3",
-    "pg-connection-string": "^2.3.0",
+    "pg": "^8.5.1",
+    "pg-connection-string": "^2.4.0",
     "serve-static": "^1.14.1"
   },
   "engines": {
@@ -109,5 +109,13 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "lint-staged": {
+    "*.js": [
+      "balena-lint --typescript --fix"
+    ],
+    "*.ts": [
+      "balena-lint --typescript --fix"
+    ]
   }
 }


### PR DESCRIPTION
Update abstract-sql-compiler from 7.0.3 to 7.0.6
Update lf-to-abstract-sql from 4.1.0 to 4.1.1
Update odata-parser from 2.2.0 to 2.2.1
Update odata-to-abstract-sql from 5.3.0 to 5.3.1
Update sbvr-types from 3.1.0 to 3.1.2
Update pinejs-client-core from 6.9.1 to 6.9.3

Change-type: patch