### PR TITLE
Update abstract-sql-compiler to 7.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "prettify": "balena-lint -e js -e ts --typescript --fix src build typings Gruntfile.ts"
   },
   "dependencies": {
-    "@balena/abstract-sql-compiler": "^7.4.1",
+    "@balena/abstract-sql-compiler": "^7.4.2",
     "@balena/lf-to-abstract-sql": "^4.1.1",
     "@balena/odata-parser": "^2.2.1",
-    "@balena/odata-to-abstract-sql": "^5.4.0",
+    "@balena/odata-to-abstract-sql": "^5.4.1",
     "@balena/sbvr-parser": "^1.1.1",
     "@balena/sbvr-types": "^3.1.3",
     "@types/bluebird": "^3.5.33",

--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -3,6 +3,8 @@ import type {
 	AbstractSqlType,
 	AliasNode,
 	Relationship,
+	RelationshipInternalNode,
+	RelationshipLeafNode,
 	RelationshipMapping,
 	SelectNode,
 } from '@balena/abstract-sql-compiler';
@@ -289,13 +291,13 @@ const namespaceRelationships = (
 			return;
 		}
 
-		let mapping = relationship.$;
+		let mapping = (relationship as RelationshipLeafNode).$;
 		if (mapping != null && mapping.length === 2) {
 			mapping = _.cloneDeep(mapping);
 			// we do check the length above, but typescript thinks the second
 			// element could be undefined
 			mapping[1]![0] = `${mapping[1]![0]}$${alias}`;
-			relationships[`${key}$${alias}`] = {
+			(relationships as RelationshipInternalNode)[`${key}$${alias}`] = {
 				$: mapping,
 			};
 		}
@@ -856,11 +858,11 @@ const rewriteRelationship = memoizeWeak(
 const rewriteRelationships = (
 	abstractSqlModel: AbstractSqlModel,
 	relationships: {
-		[resourceName: string]: Relationship;
+		[resourceName: string]: RelationshipInternalNode;
 	},
 	permissionsLookup: PermissionLookup,
 	vocabulary: string,
-) => {
+): typeof relationships => {
 	const originalAbstractSQLModel = sbvrUtils.getAbstractSqlModel({
 		vocabulary,
 	});


### PR DESCRIPTION
Update abstract-sql-compiler from 7.4.1 to 7.4.2
Update odata-to-abstract-sql from 5.4.0 to 5.4.1

Change-type: patch
Depends-on: https://github.com/balena-io-modules/abstract-sql-compiler/pull/102
Depends-on: https://github.com/balena-io-modules/odata-to-abstract-sql/pull/70
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>