### PR TITLE
Disable the creation of a package-lock on each npm install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Just like we do in pine-client. Atm a no-op since we do not have a pakcage-lock in the repo at all.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>