### PR TITLE
Optimize generating constrained abstract sql model

### DIFF
--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -578,15 +578,11 @@ const generateConstrainedAbstractSql = (
 		}
 	};
 
-	const odata2AbstractSQL = new OData2AbstractSQL(abstractSQLModel, {
+	const { tree, extraBindVars } = memoizedGetOData2AbstractSQL(
+		abstractSQLModel,
+	).match(odata.tree, 'GET', [], odata.binds.length, {
 		canAccess: canAccessFunction,
 	});
-	const { tree, extraBindVars } = odata2AbstractSQL.match(
-		odata.tree,
-		'GET',
-		[],
-		odata.binds.length,
-	);
 
 	odata.binds.push(...extraBindVars);
 	const odataBinds = odata.binds;


### PR DESCRIPTION
Instantiating an `OData2AbstractSQL` instance can be relatively costly
and as such reusing a memoized instance can provide a reasonable
performance improvement

Change-type: patch