### PR TITLE
Update sbvr-types to 3.2.0, adding support for more `Text (Type)` verbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "prettify": "balena-lint -e js -e ts --typescript --fix src build typings Gruntfile.ts"
   },
   "dependencies": {
-    "@balena/abstract-sql-compiler": "^7.10.0",
+    "@balena/abstract-sql-compiler": "^7.10.1",
     "@balena/abstract-sql-to-typescript": "^1.1.1",
     "@balena/lf-to-abstract-sql": "^4.1.1",
     "@balena/odata-parser": "^2.2.2",
     "@balena/odata-to-abstract-sql": "^5.4.1",
     "@balena/sbvr-parser": "^1.1.1",
-    "@balena/sbvr-types": "^3.1.3",
+    "@balena/sbvr-types": "^3.2.0",
     "@types/bluebird": "^3.5.33",
     "@types/body-parser": "^1.19.0",
     "@types/compression": "^1.7.0",


### PR DESCRIPTION
Update abstract-sql-compiler from 7.10.0 to 7.10.1
Update sbvr-types from 3.1.3 to 3.2.0

Change-type: minor