### PR TITLE
Update abstract-sql-compiler to 7.13.0 to support CurrentTimestamp/Date

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prettify": "balena-lint -e js -e ts --typescript --fix src build typings Gruntfile.ts"
   },
   "dependencies": {
-    "@balena/abstract-sql-compiler": "^7.12.0",
+    "@balena/abstract-sql-compiler": "^7.13.0",
     "@balena/abstract-sql-to-typescript": "^1.1.1",
     "@balena/lf-to-abstract-sql": "^4.2.1",
     "@balena/odata-parser": "^2.2.3",


### PR DESCRIPTION
Update abstract-sql-compiler from 7.12.0 to 7.13.0

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>