### PR TITLE
Bump dependencies to add `is of` reverse relationship for concept types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@balena/abstract-sql-compiler": "^7.13.1",
     "@balena/abstract-sql-to-typescript": "^1.1.1",
-    "@balena/lf-to-abstract-sql": "^4.2.2",
+    "@balena/lf-to-abstract-sql": "^4.3.0",
     "@balena/odata-parser": "^2.2.5",
     "@balena/odata-to-abstract-sql": "^5.4.2",
     "@balena/sbvr-parser": "^1.2.5",


### PR DESCRIPTION
Update lf-to-abstract-sql from 4.2.2 to 4.3.0

Change-type: minor
See: https://github.com/balena-io-modules/lf-to-abstract-sql/pull/47
See: https://www.flowdock.com/app/rulemotion/platform/threads/hnT7FJDke0tWpsNrF7OfX2-bSMY
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>