### PR TITLE
Add method for getting transaction level advisory locks in Postgresql

### DIFF
--- a/src/sbvr-api/common-types.ts
+++ b/src/sbvr-api/common-types.ts
@@ -1,4 +1,4 @@
-export { AnyObject } from 'pinejs-client-core';
+export { AnyObject, Dictionary } from 'pinejs-client-core';
 
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 export type RequiredField<T, F extends keyof T> = Overwrite<


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>