### PR TITLE
Add support for a `PINEJS_DEBUG` env var that is more strictly checked

### DIFF
--- a/build/browser.ts
+++ b/build/browser.ts
@@ -19,6 +19,7 @@ config.plugins = config.plugins.concat(
 		'process.browser': true,
 		'process.env.CONFIG_LOADER_DISABLED': true,
 		'process.env.DEBUG': true,
+		'process.env.PINEJS_DEBUG': true,
 		'process.env.SBVR_SERVER_ENABLED': true,
 	}),
 );

--- a/src/config-loader/env.ts
+++ b/src/config-loader/env.ts
@@ -1,4 +1,12 @@
-export const { DEBUG } = process.env;
+// TODO-MAJOR: Drop the support for the global `DEBUG` env var
+const { DEBUG: globalDebug, PINEJS_DEBUG } = process.env;
+if (![undefined, '', '0', '1'].includes(PINEJS_DEBUG)) {
+	// TODO-MAJOR: Throw on invalid value
+	console.warn(`Invalid value for PINE_DEBUG '${PINEJS_DEBUG}'`);
+}
+// Setting PINEJS_DEBUG to explicitly '0' will disable debug even if global debug is truthy
+export const DEBUG =
+	PINEJS_DEBUG === '1' || (PINEJS_DEBUG !== '0' && !!globalDebug);
 
 export const cache = {
 	permissionsLookup: {


### PR DESCRIPTION
This means we can warn on/ignore invalid values rather than giving a
potentially surprising result, eg `'0'` being truthy

Change-type: minor