### PR TITLE
Allow passing a function as the cache params to enable custom caching

### DIFF
--- a/src/sbvr-api/abstract-sql.ts
+++ b/src/sbvr-api/abstract-sql.ts
@@ -8,7 +8,6 @@ import {
 } from '@balena/odata-to-abstract-sql';
 import deepFreeze = require('deep-freeze');
 import * as memoize from 'memoizee';
-import memoizeWeak = require('memoizee/weak');
 import * as env from '../config-loader/env';
 import { BadRequestError, SqlCompilationError } from './errors';
 import * as sbvrUtils from './sbvr-utils';
@@ -16,7 +15,8 @@ import { ODataRequest } from './uri-parser';
 
 const getMemoizedCompileRule = memoize(
 	(engine: AbstractSQLCompiler.Engines) =>
-		memoizeWeak(
+		env.createCache(
+			'abstractSqlCompiler',
 			(abstractSqlQuery: AbstractSQLCompiler.AbstractSqlQuery) => {
 				const sqlQuery =
 					AbstractSQLCompiler[engine].compileRule(abstractSqlQuery);
@@ -30,7 +30,7 @@ const getMemoizedCompileRule = memoize(
 					modifiedFields,
 				};
 			},
-			{ max: env.cache.abstractSqlCompiler.max },
+			{ weak: true },
 		),
 	{ primitive: true },
 );

--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -117,7 +117,8 @@ const methodPermissions: {
 	DELETE: 'delete',
 };
 
-const $parsePermissions = memoize(
+const $parsePermissions = env.createCache(
+	'parsePermissions',
 	(filter: string) => {
 		const { tree, binds } = ODataParser.parse(filter, {
 			startRule: 'ProcessRule',
@@ -130,7 +131,6 @@ const $parsePermissions = memoize(
 	},
 	{
 		primitive: true,
-		max: env.cache.parsePermissions.max,
 	},
 );
 
@@ -308,7 +308,8 @@ const namespaceRelationships = (
 
 type PermissionLookup = _.Dictionary<true | string[]>;
 
-const getPermissionsLookup = memoize(
+const getPermissionsLookup = env.createCache(
+	'permissionsLookup',
 	(permissions: string[], guestPermissions?: string[]): PermissionLookup => {
 		if (guestPermissions != null) {
 			permissions = [...guestPermissions, ...permissions];
@@ -339,10 +340,10 @@ const getPermissionsLookup = memoize(
 		return permissionsLookup;
 	},
 	{
+		weak: undefined,
 		normalizer: ([permissions, guestPermissions]) =>
 			// When guestPermissions is present it should always be the same, so we can key by presence not content
 			`${permissions}${guestPermissions == null}`,
-		max: env.cache.permissionsLookup.max,
 	},
 );
 

--- a/src/sbvr-api/uri-parser.ts
+++ b/src/sbvr-api/uri-parser.ts
@@ -13,7 +13,6 @@ import * as ODataParser from '@balena/odata-parser';
 export const SyntaxError = ODataParser.SyntaxError;
 import { OData2AbstractSQL } from '@balena/odata-to-abstract-sql';
 import * as _ from 'lodash';
-import * as memoize from 'memoizee';
 import memoizeWeak = require('memoizee/weak');
 
 export { BadRequestError, ParsingError, TranslationError } from './errors';
@@ -87,9 +86,8 @@ export const memoizedParseOdata = (() => {
 		return odata;
 	};
 
-	const _memoizedParseOdata = memoize(parseOdata, {
+	const _memoizedParseOdata = env.createCache('parseOData', parseOdata, {
 		primitive: true,
-		max: env.cache.parseOData.max,
 	});
 	return (url: string) => {
 		const queryParamsIndex = url.indexOf('?');
@@ -149,7 +147,8 @@ export const memoizedGetOData2AbstractSQL = memoizeWeak(
 );
 
 const memoizedOdata2AbstractSQL = (() => {
-	const $memoizedOdata2AbstractSQL = memoizeWeak(
+	const $memoizedOdata2AbstractSQL = env.createCache(
+		'odataToAbstractSql',
 		(
 			abstractSqlModel: AbstractSQLCompiler.AbstractSqlModel,
 			odataQuery: ODataQuery,
@@ -199,7 +198,7 @@ const memoizedOdata2AbstractSQL = (() => {
 					existingBindVarsLength
 				);
 			},
-			max: env.cache.odataToAbstractSql.max,
+			weak: true,
 		},
 	);
 	const cachedProps = [

--- a/typings/memoizee.d.ts
+++ b/typings/memoizee.d.ts
@@ -5,7 +5,7 @@ declare module 'memoizee/weak' {
 	type RestArgs<T> = T extends (arg1: any, ...args: infer U) => any ? U : any[];
 
 	// tslint:disable-next-line ban-types
-	interface MemoizeWeakOptions<F extends Function> {
+	export interface MemoizeWeakOptions<F extends Function> {
 		length?: number | false;
 		maxAge?: number;
 		max?: number;


### PR DESCRIPTION
This allows using a different cache than the default of memoizee

Change-type: minor