### PR TITLE
Update dependencies for referenceType

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "prettify": "balena-lint -e js -e ts --fix src build typings Gruntfile.ts"
   },
   "dependencies": {
-    "@balena/abstract-sql-compiler": "^7.17.1",
+    "@balena/abstract-sql-compiler": "^7.18.0",
     "@balena/abstract-sql-to-typescript": "^1.1.1",
-    "@balena/lf-to-abstract-sql": "^4.4.1",
+    "@balena/lf-to-abstract-sql": "^4.5.0",
     "@balena/odata-parser": "^2.2.8",
     "@balena/odata-to-abstract-sql": "^5.4.8",
-    "@balena/sbvr-parser": "^1.3.0",
+    "@balena/sbvr-parser": "^1.4.0",
     "@balena/sbvr-types": "^3.4.6",
     "@types/body-parser": "^1.19.2",
     "@types/compression": "^1.7.2",


### PR DESCRIPTION
Update @balena/abstract-sql-compiler from 7.17.1 to 7.18.0
Update @balena/lf-to-abstract-sql from 4.4.1 to 4.5.0
Update @balena/sbvr-parser from 1.3.0 to 1.4.0

Change-type: minor
Signed-off-by: Harald Fischer <harald@balena.io>