### PR TITLE
Add cross-usable flag for model exists before init

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "balena-lint -e js -e ts src build typings Gruntfile.ts && npx tsc --project tsconfig.dev.json --noEmit",
     "test": "npm run lint & npm run build && npm run webpack-build",
     "test:compose": "npm run compose:build && npm run compose:postgres && docker-compose -f docker-compose.test.yml run sut npm run mocha",
-    "test:fast": " npm run compose:postgres && npm run mocha:local",
+    "test:fast": "npm run compose:postgres && npm run mocha:local",
     "mocha": "TS_NODE_FILES=true mocha",
     "mocha:local": "DATABASE_URL=postgres://docker:docker@localhost:5431/postgres npm run mocha",
     "compose:postgres": "docker-compose -f docker-compose.test.yml up -d postgres",

--- a/src/migrator/sync.ts
+++ b/src/migrator/sync.ts
@@ -3,7 +3,6 @@ import {
 	MigrationTuple,
 	MigrationError,
 	defaultMigrationCategory,
-	checkModelAlreadyExists,
 	setExecutedMigrations,
 	getExecutedMigrations,
 	lockMigrations,
@@ -25,10 +24,10 @@ export const postRun = async (tx: Tx, model: ApiRootModel): Promise<void> => {
 
 	const modelName = model.apiRoot;
 
-	const exists = await checkModelAlreadyExists(tx, modelName);
+	const exists = await sbvrUtils.isModelNew(tx, modelName);
 	if (!exists) {
 		(sbvrUtils.api.migrations?.logger.info ?? console.info)(
-			'First time executing, running init script',
+			`First time executing ${modelName}, running init script`,
 		);
 
 		await lockMigrations(tx, modelName, async () => {
@@ -69,10 +68,10 @@ const $run = async (
 
 	// migrations only run if the model has been executed before,
 	// to make changes that can't be automatically applied
-	const exists = await checkModelAlreadyExists(tx, modelName);
+	const exists = await sbvrUtils.isModelNew(tx, modelName);
 	if (!exists) {
 		(sbvrUtils.api.migrations?.logger.info ?? console.info)(
-			'First time model has executed, skipping migrations',
+			`First time model ${modelName} has executed, skipping migrations`,
 		);
 
 		return await setExecutedMigrations(tx, modelName, Object.keys(migrations));

--- a/src/migrator/utils.ts
+++ b/src/migrator/utils.ts
@@ -88,26 +88,6 @@ WHERE "model name" = ${1}`,
 	}
 };
 
-export const checkModelAlreadyExists = async (
-	tx: Tx,
-	modelName: string,
-): Promise<boolean> => {
-	const result = await tx.tableList("name = 'migration'");
-	if (result.rows.length === 0) {
-		return false;
-	}
-	const { rows } = await tx.executeSql(
-		binds`
-SELECT 1
-FROM "model"
-WHERE "model"."is of-vocabulary" = ${1}
-LIMIT 1`,
-		[modelName],
-	);
-
-	return rows.length > 0;
-};
-
 export const setExecutedMigrations = async (
 	tx: Tx,
 	modelName: string,

--- a/test/fixtures/02-sync-migrator/04-new-model-with-init.ts
+++ b/test/fixtures/02-sync-migrator/04-new-model-with-init.ts
@@ -1,0 +1,32 @@
+import type { ConfigLoader } from '../../../src/server-glue/module';
+
+const apiRoot = 'example';
+const modelName = 'example';
+const modelFile = __dirname + '/example.sbvr';
+
+export default {
+	models: [
+		{
+			modelName,
+			modelFile,
+			apiRoot,
+			migrations: {
+				'0001': `
+					INSERT INTO "device" ("id", "name", "note", "type")
+					VALUES (2, 'no run', 'shouldNotRun', 'empty')			
+				`,
+			},
+			initSql: `
+				INSERT INTO "device" ("id", "name", "note", "type")
+				VALUES (1, 'initName', 'shouldBeInit', 'init')			
+			`,
+		},
+	],
+	users: [
+		{
+			username: 'guest',
+			password: ' ',
+			permissions: ['resource.all'],
+		},
+	],
+} as ConfigLoader.Config;

--- a/test/fixtures/02-sync-migrator/example.sbvr
+++ b/test/fixtures/02-sync-migrator/example.sbvr
@@ -1,21 +1,21 @@
 Vocabulary: example
 
 Term: name
-	  Concept Type: Short Text (Type)
+	Concept Type: Short Text (Type)
 
 Term: note
-	  Concept Type: Text (Type)
+	Concept Type: Text (Type)
 
 Term: type
-	  Concept Type: Short Text (Type)
+	Concept Type: Short Text (Type)
 
 Term: device
 
 Fact Type: device has name
-	 Necessity: each device has at most one name.
+	Necessity: each device has at most one name.
 
 Fact Type: device has note
-	 Necessity: each device has at most one note.
+	Necessity: each device has at most one note.
 
 Fact Type: device has type
-	 Necessity: each device has exactly one type.
+	Necessity: each device has exactly one type.


### PR DESCRIPTION
Modules may need to know if a model existed before initialisation of the instance.
Eg. migrations need to know if a model is freshly generated / executed
of if this model already existed and can be target for migrations.

Change-type: minor
Signed-off-by: Harald Fischer <harald@balena.io>