### PR TITLE
Refactor checkModelExists to isModelNew

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "balena-lint -e js -e ts src build typings Gruntfile.ts && npx tsc --project tsconfig.dev.json --noEmit",
     "test": "npm run lint & npm run build && npm run webpack-build",
     "test:compose": "npm run compose:build && npm run compose:postgres && docker-compose -f docker-compose.test.yml run sut npm run mocha",
-    "test:fast": " npm run compose:postgres && npm run mocha:local",
+    "test:fast": "npm run compose:postgres && npm run mocha:local",
     "mocha": "TS_NODE_FILES=true mocha",
     "mocha:local": "DATABASE_URL=postgres://docker:docker@localhost:5431/postgres npm run mocha",
     "compose:postgres": "docker-compose -f docker-compose.test.yml up -d postgres",

--- a/test/fixtures/02-sync-migrator/04-new-model-with-init.ts
+++ b/test/fixtures/02-sync-migrator/04-new-model-with-init.ts
@@ -1,0 +1,32 @@
+import type { ConfigLoader } from '../../../src/server-glue/module';
+
+const apiRoot = 'example';
+const modelName = 'example';
+const modelFile = __dirname + '/example.sbvr';
+
+export default {
+	models: [
+		{
+			modelName,
+			modelFile,
+			apiRoot,
+			migrations: {
+				'0001': `
+					INSERT INTO "device" ("id", "name", "note", "type")
+					VALUES (2, 'no run', 'shouldNotRun', 'empty')			
+				`,
+			},
+			initSql: `
+				INSERT INTO "device" ("id", "name", "note", "type")
+				VALUES (1, 'initName', 'shouldBeInit', 'init')			
+			`,
+		},
+	],
+	users: [
+		{
+			username: 'guest',
+			password: ' ',
+			permissions: ['resource.all'],
+		},
+	],
+} as ConfigLoader.Config;

--- a/test/fixtures/02-sync-migrator/example.sbvr
+++ b/test/fixtures/02-sync-migrator/example.sbvr
@@ -1,21 +1,21 @@
 Vocabulary: example
 
 Term: name
-	  Concept Type: Short Text (Type)
+	Concept Type: Short Text (Type)
 
 Term: note
-	  Concept Type: Text (Type)
+	Concept Type: Text (Type)
 
 Term: type
-	  Concept Type: Short Text (Type)
+	Concept Type: Short Text (Type)
 
 Term: device
 
 Fact Type: device has name
-	 Necessity: each device has at most one name.
+	Necessity: each device has at most one name.
 
 Fact Type: device has note
-	 Necessity: each device has at most one note.
+	Necessity: each device has at most one note.
 
 Fact Type: device has type
-	 Necessity: each device has exactly one type.
+	Necessity: each device has exactly one type.


### PR DESCRIPTION
Modules may need to know if a model existed before initialisation of the instance.
Eg. migrations need to know if a model is freshly generated / executed
of if this model already existed and can be target for migrations.

Change-type: minor
Signed-off-by: Harald Fischer <harald@balena.io>