### PR TITLE
Differentiate typings between parsed and processed odata requests

### DIFF
--- a/src/sbvr-api/abstract-sql.ts
+++ b/src/sbvr-api/abstract-sql.ts
@@ -173,7 +173,10 @@ const checkModifiedFields = (
 };
 export const isRuleAffected = (
 	rule: AbstractSQLCompiler.SqlRule,
-	request?: ODataRequest,
+	request?: Pick<
+		ODataRequest,
+		'abstractSqlQuery' | 'modifiedFields' | 'method' | 'vocabulary'
+	>,
 ) => {
 	// If there is no abstract sql query then nothing was modified
 	if (request?.abstractSqlQuery == null) {

--- a/src/sbvr-api/hooks.ts
+++ b/src/sbvr-api/hooks.ts
@@ -1,6 +1,6 @@
 import type { OptionalField, Resolvable } from './common-types';
 import type { Tx } from '../database-layer/db';
-import type { ODataRequest } from './uri-parser';
+import type { ODataRequest, ParsedODataRequest } from './uri-parser';
 import type { AnyObject } from 'pinejs-client-core';
 import type { TypedError } from 'typed-error';
 import type { SupportedMethod } from '@balena/odata-to-abstract-sql';
@@ -194,14 +194,17 @@ const getMethodHooks = memoize(
 );
 export const getHooks = (
 	request: Pick<
-		OptionalField<ODataRequest, 'resourceName'>,
+		OptionalField<ParsedODataRequest, 'resourceName'>,
 		'resourceName' | 'method' | 'vocabulary'
 	>,
 ): InstantiatedHooks => {
 	let { resourceName } = request;
 	if (resourceName != null) {
 		resourceName = resolveSynonym(
-			request as Pick<ODataRequest, 'resourceName' | 'method' | 'vocabulary'>,
+			request as Pick<
+				ParsedODataRequest,
+				'resourceName' | 'method' | 'vocabulary'
+			>,
 		);
 	}
 	return instantiateHooks(


### PR DESCRIPTION
This allows us to make properties on the process odata request required
whereas previously they had to be optional in order to be compatible,
as of now this only affects the `engine` property but in future further
properties of the processed request could be made required. And even at
this point it will block passing a parsed only request object to a
function expecting a processed request object

Change-type: patch