### PR TITLE
Make checking that read-only TX queries are SELECT queries optional

### DIFF
--- a/src/config-loader/env.ts
+++ b/src/config-loader/env.ts
@@ -104,6 +104,15 @@ export const db = {
 	timeoutMS,
 	maxUses: Infinity,
 	maxLifetimeSeconds: 0,
+	/**
+	 * Check that queries in read-only TXs only contain `SELECT` statements, doing so adds a cost to each query
+	 * in a read-only TX and is unnecessary if it is part of a read-only database transaction. The only time a
+	 * writable transaction should be used with a read-only TX is during a read-only hook within a writable request
+	 * and so should only be able to catch cases of hooks that are incorrectly marked as read-only
+	 *
+	 * Defaults to true when in DEBUG mode, false otherwise
+	 */
+	checkReadOnlyQueries: DEBUG,
 };
 
 export const migrator = {

--- a/src/database-layer/db.ts
+++ b/src/database-layer/db.ts
@@ -292,7 +292,11 @@ export abstract class Tx {
 		bindings: Bindings = [],
 		...args: any[]
 	): Promise<Result> {
-		if (this.readOnly && !/^\s*SELECT\s(?:[^;]|;\s*SELECT\s)*$/.test(sql)) {
+		if (
+			env.db.checkReadOnlyQueries &&
+			this.readOnly &&
+			!/^\s*SELECT\s(?:[^;]|;\s*SELECT\s)*$/.test(sql)
+		) {
 			throw new ReadOnlyViolationError(
 				`Attempted to run a non-SELECT statement in a read-only tx: ${sql}`,
 			);


### PR DESCRIPTION
This removes a cost per query which is generally unnecessary and can
add up to being significant in read heavy workloads

Change-type: minor