### PR TITLE
Fixing issue reported by tsc 4.8.2

### DIFF
--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -175,19 +175,19 @@ const isAnd = <T>(x: any): x is NestedCheckAnd<T> =>
 	typeof x === 'object' && 'and' in x;
 const isOr = <T>(x: any): x is NestedCheckOr<T> =>
 	typeof x === 'object' && 'or' in x;
-export function nestedCheck<I, O>(
+export function nestedCheck<I extends {}, O>(
 	check: string,
 	stringCallback: (s: string) => O,
 ): O;
-export function nestedCheck<I, O>(
+export function nestedCheck<I extends {}, O>(
 	check: boolean,
 	stringCallback: (s: string) => O,
 ): boolean;
-export function nestedCheck<I, O>(
+export function nestedCheck<I extends {}, O>(
 	check: NestedCheck<I>,
 	stringCallback: (s: string) => O,
 ): Exclude<I, string> | O | MappedNestedCheck<typeof check, I, O>;
-export function nestedCheck<I, O>(
+export function nestedCheck<I extends {}, O>(
 	check: NestedCheck<I>,
 	stringCallback: (s: string) => O,
 ): boolean | Exclude<I, string> | O | MappedNestedCheck<typeof check, I, O> {


### PR DESCRIPTION
Inferenced type of check could be I & null
when I is not set in the overload.

Issue reported:
```
Using tsc v4.8.2
src/sbvr-api/permissions.ts(225,34): error TS2769: No overload matches this call.
  Overload 1 of 2, '(o: {}): string[]', gave the following error.
    Argument of type 'NestedCheckOr<I> | NestedCheckAnd<I> | (I & object) | (I & null)' is not assignable to parameter of type '{}'.
      Type 'I & null' is not assignable to type '{}'.
  Overload 2 of 2, '(o: object): string[]', gave the following error.
    Argument of type 'NestedCheckOr<I> | NestedCheckAnd<I> | (I & object) | (I & null)' is not assignable to parameter of type 'object'.
      Type 'I & null' is not assignable to type 'object'.

>> 1 non-emit-preventing type warning  
>> Error: tsc return code: 2
Warning: Task "ts:default" failed. Use --force to continue.
````



Change-type: patch
Signed-off-by: Harald Fischer <harald@balena.io>