### PR TITLE
Remove prepublishOnly lint step

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "scripts": {
     "prepublish": "require-npm4-to-publish",
-    "prepublishOnly": "npm run lint",
     "prepare": "npm run build",
     "build": "grunt build",
     "webpack-browser": "grunt browser",
@@ -136,9 +135,7 @@
     "extension": [
       ".test.ts"
     ],
-    "require": [
-      "ts-node/register"
-    ],
+    "require": "ts-node/register/transpile-only",
     "exit": true,
     "timeout": 60000,
     "recursive": true


### PR DESCRIPTION
It is already run as part of the tests which are required by CI before it'll publish, and avoids issues when publishing without dev deps

Change-type: patch