### PR TITLE
Use minimized aliases when not in debug mode for smaller queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "prettify": "balena-lint -e js -e ts --fix src build typings Gruntfile.ts"
   },
   "dependencies": {
-    "@balena/abstract-sql-compiler": "^7.21.0",
+    "@balena/abstract-sql-compiler": "^7.21.1",
     "@balena/abstract-sql-to-typescript": "^1.2.0",
     "@balena/lf-to-abstract-sql": "^4.5.1",
     "@balena/odata-parser": "^2.4.0",
-    "@balena/odata-to-abstract-sql": "^5.5.0",
+    "@balena/odata-to-abstract-sql": "^5.6.2",
     "@balena/sbvr-parser": "^1.4.1",
     "@balena/sbvr-types": "^3.4.7",
     "@types/body-parser": "^1.19.2",

--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -26,7 +26,7 @@ import type { AnyObject, Dictionary } from './common-types';
 
 import {
 	isBindReference,
-	OData2AbstractSQL,
+	type OData2AbstractSQL,
 	odataNameToSqlName,
 	ResourceFunction,
 	sqlNameToODataName,

--- a/src/sbvr-api/uri-parser.ts
+++ b/src/sbvr-api/uri-parser.ts
@@ -144,7 +144,10 @@ export const memoizedParseOdata = (() => {
 
 export const memoizedGetOData2AbstractSQL = memoizeWeak(
 	(abstractSqlModel: AbstractSQLCompiler.AbstractSqlModel) => {
-		return new OData2AbstractSQL(abstractSqlModel);
+		return new OData2AbstractSQL(abstractSqlModel, undefined, {
+			// Use minimized aliases when not in debug mode for smaller queries
+			minimizeAliases: !env.DEBUG,
+		});
 	},
 );
 


### PR DESCRIPTION
Update @balena/odata-to-abstract-sql from 5.5.0 to 5.6.0

Change-type: patch