### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "prettify": "balena-lint -e js -e ts --fix src build typings Gruntfile.ts"
   },
   "dependencies": {
-    "@balena/abstract-sql-compiler": "^7.21.1",
-    "@balena/abstract-sql-to-typescript": "^1.2.0",
+    "@balena/abstract-sql-compiler": "^7.22.0",
+    "@balena/abstract-sql-to-typescript": "^1.3.0",
     "@balena/lf-to-abstract-sql": "^4.5.1",
     "@balena/odata-parser": "^2.4.0",
-    "@balena/odata-to-abstract-sql": "^5.6.2",
+    "@balena/odata-to-abstract-sql": "^5.7.0",
     "@balena/sbvr-parser": "^1.4.1",
     "@balena/sbvr-types": "^3.4.7",
     "@types/body-parser": "^1.19.2",


### PR DESCRIPTION
Update @balena/abstract-sql-compiler from 7.21.1 to 7.22.0 
Update @balena/abstract-sql-to-typescript from 1.2.0 to 1.3.0 
Update @balena/odata-to-abstract-sql from 5.6.2 to 5.7.0

Change-type: minor
Signed-off-by: fisehara <harald@balena.io>