### PR TITLE
Introduce control means for async migration execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@balena/abstract-sql-compiler": "^7.25.3",
     "@balena/abstract-sql-to-typescript": "^1.3.0",
     "@balena/lf-to-abstract-sql": "^4.7.0",
+    "@balena/env-parsing": "^1.1.0",
     "@balena/odata-parser": "^2.4.2",
     "@balena/odata-to-abstract-sql": "^5.8.0",
     "@balena/sbvr-parser": "^1.4.3",

--- a/src/config-loader/env.ts
+++ b/src/config-loader/env.ts
@@ -53,6 +53,7 @@ export const cache = {
 	apiKeyActorId: false as CacheOpts,
 };
 
+import { boolVar } from '@balena/env-parsing';
 import * as memoize from 'memoizee';
 import memoizeWeak = require('memoizee/weak');
 export const createCache = <T extends (...args: any[]) => any>(
@@ -119,6 +120,9 @@ export const PINEJS_ADVISORY_LOCK = {
 	namespaceKey: 'pinejs_advisory_lock_namespace',
 	namespaceId: -1,
 };
+// for better readability of logging
+export const booleanToEnabledString = (input: boolean) =>
+	input ? 'enabled' : 'disabled';
 
 export const migrator = {
 	lockTimeout: 5 * 60 * 1000,
@@ -128,4 +132,21 @@ export const migrator = {
 	asyncMigrationDefaultBackoffDelayMS: 60000,
 	asyncMigrationDefaultErrorThreshold: 10,
 	asyncMigrationDefaultBatchSize: 1000,
+
+	/**
+	 * @param asyncMigrationIsEnabled Switch on/off the execution of async migrations
+	 * Example implementation with listening on SIGUSR2 to toggle the AsyncMigrationExecution enable switch
+	 * For runtime switching the async migration execution the SIGUSR2 signal is interpreted as toggle.
+	 * When the process receives a SIGUSR2 signal the async migrations will toggle to be enabled or disabled.
+	 * @example
+	 * process.on('SIGUSR2', () => {
+	 * 	console.info(
+	 * 		`Received SIGUSR2 to toggle async migration execution enabled
+	 * 					from ${migrator.asyncMigrationIsEnabled}
+	 * 					to ${!migrator.asyncMigrationIsEnabled} `,
+	 * 	);
+	 * 	migrator.asyncMigrationIsEnabled = !migrator.asyncMigrationIsEnabled;
+	 * });
+	 */
+	asyncMigrationIsEnabled: boolVar('PINEJS_ASYNC_MIGRATION_ENABLED', true),
 };

--- a/test/fixtures/03-async-migrator/01-migrations/migrations/0002-test-migrations.async.ts
+++ b/test/fixtures/03-async-migrator/01-migrations/migrations/0002-test-migrations.async.ts
@@ -26,8 +26,8 @@ const migration: AsyncMigration = {
         `;
 		await tx.executeSql(staticSql);
 	},
-	delayMS: 250,
-	backoffDelayMS: 4000,
+	delayMS: 50,
+	backoffDelayMS: 1000,
 	errorThreshold: 15,
 	finalize: false,
 };

--- a/test/lib/pine-init.ts
+++ b/test/lib/pine-init.ts
@@ -15,6 +15,16 @@ export async function init(
 		res.sendStatus(200);
 	});
 
+	process.on('SIGUSR2', () => {
+		console.info(
+			`Received SIGUSR2 to toggle async migration execution enabled from ${
+				pine.env.migrator.asyncMigrationIsEnabled
+			} to ${!pine.env.migrator.asyncMigrationIsEnabled} `,
+		);
+		pine.env.migrator.asyncMigrationIsEnabled =
+			!pine.env.migrator.asyncMigrationIsEnabled;
+	});
+
 	try {
 		await cleanInit(deleteDb);
 		await pine.init(app, initConfig);


### PR DESCRIPTION
Introduce env var PINEJS_ASYNC_MIGRATION_ENABLED to control async migration execution on startup. Introduce SIGUSR2 listener to toggle migration execution during runtime.

Change-type: minor
Signed-off-by: fisehara <harald@balena.io>