### PR TITLE
Use postgres advisory locks for migration locking.

### DIFF
--- a/src/config-loader/env.ts
+++ b/src/config-loader/env.ts
@@ -115,6 +115,11 @@ export const db = {
 	checkReadOnlyQueries: DEBUG,
 };
 
+export const PINEJS_ADVISORY_LOCK = {
+	namespaceKey: 'pinejs_advisory_lock_namespace',
+	namespaceId: -1,
+};
+
 export const migrator = {
 	lockTimeout: 5 * 60 * 1000,
 	// Used to delay the failure on lock taking, to avoid spam taking

--- a/src/migrator/async.ts
+++ b/src/migrator/async.ts
@@ -201,77 +201,83 @@ const $run = async (
 				try {
 					const $migrationState = await sbvrUtils.db.transaction(
 						async (tx) =>
-							await lockMigrations(tx, modelName, async () => {
-								const migrationState = await readMigrationStatus(tx, key);
+							await lockMigrations(
+								{ tx, modelName, blocking: false },
+								async () => {
+									const migrationState = await readMigrationStatus(tx, key);
 
-								if (!migrationState) {
-									// migration status is unclear stop the migrator
-									// or migration should stop
-									(sbvrUtils.api.migrations?.logger.info ?? console.info)(
-										`stopping async migration due to missing migration status: ${key}`,
-									);
-									return false;
-								}
-								// sync on the last execution time between instances
-								// precondition: All running instances are running on the same time/block
-								// skip execution
-								if (migrationState.last_run_time) {
-									const durationSinceLastRun =
-										Date.now() - migrationState.last_run_time.getTime();
-									const delayMs = migrationState.is_backing_off
-										? initMigrationState.backoffDelayMS
-										: initMigrationState.delayMS;
-									if (durationSinceLastRun < delayMs) {
-										// will still execute finally block where the migration lock is released.
-										return;
-									}
-								}
-								try {
-									// here a separate transaction is needed as this migration may fail
-									// when it fails it would break the transaction for managing the migration status
-									const migratedRows = await sbvrUtils.db.transaction(
-										async (migrationTx) => {
-											return (await asyncRunnerMigratorFn?.(migrationTx)) ?? 0;
-										},
-									);
-									migrationState.migrated_row_count += migratedRows;
-									if (migratedRows === 0) {
-										// when all rows have been catched up once we only catch up less frequently
-										migrationState.is_backing_off = true;
-										// only store the first time when migrator converged to all data migrated
-										migrationState.converged_time ??= new Date();
-									} else {
-										// Only here for the case that after backoff more rows need to be caught up faster
-										// If rows have been updated recently we start the interval again with normal frequency
-										migrationState.is_backing_off = false;
-									}
-								} catch (err: unknown) {
-									migrationState.error_count++;
-									if (err instanceof Error) {
-										if (
-											migrationState.error_count %
-												initMigrationState.errorThreshold ===
-											0
-										) {
-											(sbvrUtils.api.migrations?.logger.error ?? console.error)(
-												`${key}: ${err.name} ${err.message}`,
-											);
-											migrationState.is_backing_off = true;
-										}
-									} else {
-										(sbvrUtils.api.migrations?.logger.error ?? console.error)(
-											`async migration error unknown: ${key}: ${err}`,
+									if (!migrationState) {
+										// migration status is unclear stop the migrator
+										// or migration should stop
+										(sbvrUtils.api.migrations?.logger.info ?? console.info)(
+											`stopping async migration due to missing migration status: ${key}`,
 										);
+										return false;
 									}
-								} finally {
-									// using finally as it will also run when return statement is called inside the try block
-									// either success or error release the lock
-									migrationState.last_run_time = new Date();
-									migrationState.run_count += 1;
-									await updateMigrationStatus(tx, migrationState);
-								}
-								return migrationState;
-							}),
+									// sync on the last execution time between instances
+									// precondition: All running instances are running on the same time/block
+									// skip execution
+									if (migrationState.last_run_time) {
+										const durationSinceLastRun =
+											Date.now() - migrationState.last_run_time.getTime();
+										const delayMs = migrationState.is_backing_off
+											? initMigrationState.backoffDelayMS
+											: initMigrationState.delayMS;
+										if (durationSinceLastRun < delayMs) {
+											// will still execute finally block where the migration lock is released.
+											return;
+										}
+									}
+									try {
+										// here a separate transaction is needed as this migration may fail
+										// when it fails it would break the transaction for managing the migration status
+										const migratedRows = await sbvrUtils.db.transaction(
+											async (migrationTx) => {
+												return (
+													(await asyncRunnerMigratorFn?.(migrationTx)) ?? 0
+												);
+											},
+										);
+										migrationState.migrated_row_count += migratedRows;
+										if (migratedRows === 0) {
+											// when all rows have been catched up once we only catch up less frequently
+											migrationState.is_backing_off = true;
+											// only store the first time when migrator converged to all data migrated
+											migrationState.converged_time ??= new Date();
+										} else {
+											// Only here for the case that after backoff more rows need to be caught up faster
+											// If rows have been updated recently we start the interval again with normal frequency
+											migrationState.is_backing_off = false;
+										}
+									} catch (err: unknown) {
+										migrationState.error_count++;
+										if (err instanceof Error) {
+											if (
+												migrationState.error_count %
+													initMigrationState.errorThreshold ===
+												0
+											) {
+												(
+													sbvrUtils.api.migrations?.logger.error ??
+													console.error
+												)(`${key}: ${err.name} ${err.message}`);
+												migrationState.is_backing_off = true;
+											}
+										} else {
+											(sbvrUtils.api.migrations?.logger.error ?? console.error)(
+												`async migration error unknown: ${key}: ${err}`,
+											);
+										}
+									} finally {
+										// using finally as it will also run when return statement is called inside the try block
+										// either success or error release the lock
+										migrationState.last_run_time = new Date();
+										migrationState.run_count += 1;
+										await updateMigrationStatus(tx, migrationState);
+									}
+									return migrationState;
+								},
+							),
 					);
 					if ($migrationState === false) {
 						// We've stopped the migration intentionally

--- a/src/migrator/sync.ts
+++ b/src/migrator/sync.ts
@@ -30,7 +30,7 @@ export const postRun = async (tx: Tx, model: ApiRootModel): Promise<void> => {
 			`First time executing '${modelName}', running init script`,
 		);
 
-		await lockMigrations(tx, modelName, async () => {
+		await lockMigrations({ tx, modelName, blocking: true }, async () => {
 			try {
 				await tx.executeSql(initSql);
 			} catch (err: any) {
@@ -69,7 +69,7 @@ const $run = async (
 
 		return await setExecutedMigrations(tx, modelName, Object.keys(migrations));
 	}
-	await lockMigrations(tx, modelName, async () => {
+	await lockMigrations({ tx, modelName, blocking: true }, async () => {
 		try {
 			const executedMigrations = await getExecutedMigrations(tx, modelName);
 			const pendingMigrations = filterAndSortPendingMigrations(

--- a/src/migrator/utils.ts
+++ b/src/migrator/utils.ts
@@ -1,11 +1,13 @@
 import type { Result, Tx } from '../database-layer/db';
 import type { Resolvable } from '../sbvr-api/common-types';
 
+import { createHash } from 'crypto';
 import { Engines } from '@balena/abstract-sql-compiler';
 import * as _ from 'lodash';
 import { TypedError } from 'typed-error';
 import { migrator as migratorEnv } from '../config-loader/env';
 export { migrator as migratorEnv } from '../config-loader/env';
+import { PINEJS_ADVISORY_LOCK } from '../config-loader/env';
 import { delay } from '../sbvr-api/control-flow';
 
 // tslint:disable-next-line:no-var-requires
@@ -65,6 +67,11 @@ export function isAsyncMigration(
 	return (migration as AsyncMigration).type === MigrationCategories.async;
 }
 
+export function isSyncMigration(
+	migration: string | MigrationFn | RunnableMigrations,
+): migration is MigrationFn {
+	return typeof migration === 'function' || typeof migration === 'string';
+}
 export function areCategorizedMigrations(
 	migrations: Migrations,
 ): migrations is CategorizedMigrations {
@@ -130,7 +137,7 @@ export const getRunnableSyncMigrations = (
 						if (migration.finalize) {
 							runnableMigrations[key] = migration.syncFn ?? migration.syncSql;
 						}
-					} else {
+					} else if (isSyncMigration(migration)) {
 						runnableMigrations[key] = migration;
 					}
 				}
@@ -170,15 +177,20 @@ export const binds = (strings: TemplateStringsArray, ...bindNums: number[]) =>
 		})
 		.join('');
 
-export const lockMigrations = async <T>(
+/**
+ * Lock mechanism that tries to write model name to the migration lock table
+ * This creates an index write lock on this row. This lock is never persisted
+ * as the lock is hold only in the transaction and is delete at the end of the
+ * transaction.
+ *
+ * Disadvantage is that no blocking-wait queue can be generated on this lock mechanism
+ * It's database engine agnostic and works also for webSQL
+ */
+const $lockMigrations = async <T>(
 	tx: Tx,
 	modelName: string,
 	fn: () => Promise<T>,
 ): Promise<T | undefined> => {
-	if (!(await migrationTablesExist(tx))) {
-		return;
-	}
-
 	try {
 		await tx.executeSql(
 			binds`
@@ -212,6 +224,42 @@ WHERE "model name" = ${1}`,
 			// rolling back the transaction, and if we rethrow here we'll overwrite the real error
 			// making it much harder for users to see what went wrong and fix it
 		}
+	}
+};
+
+export const lockMigrations = async <T>(
+	options: { tx: Tx; modelName: string; blocking: boolean },
+	fn: () => Promise<T>,
+): Promise<T | undefined> => {
+	if (!(await migrationTablesExist(options.tx))) {
+		return;
+	}
+
+	if (sbvrUtils.db.engine === Engines.websql) {
+		return $lockMigrations(options.tx, options.modelName, fn);
+	} else if (sbvrUtils.db.engine === Engines.mysql) {
+		// right now the mysql locks are not testable
+		// pinejs generates models that are not executable on mysql databases
+		return $lockMigrations(options.tx, options.modelName, fn);
+	} else if (sbvrUtils.db.engine === Engines.postgres) {
+		// getTxLevelLock expects a 4 byte integer as the lock key.
+		// Therefore the model name is hashed and the first 4 bytes are taken as the Integer representation.
+		const modelKey: number = createHash('shake128', { outputLength: 4 })
+			.update('resin')
+			.digest()
+			.readInt32BE();
+		const lockStatus = await options.tx.getTxLevelLock(
+			PINEJS_ADVISORY_LOCK.namespaceKey,
+			modelKey,
+			options.blocking,
+		);
+
+		if (lockStatus) {
+			return await fn();
+		}
+	} else {
+		// we report any error here, as no error should happen at all
+		throw new Error(`unknown database engine for getting migration locks`);
 	}
 };
 
@@ -270,7 +318,7 @@ WHERE "migration"."model name" = ${1}`,
 };
 
 export const migrationTablesExist = async (tx: Tx) => {
-	const tables = ['migration', 'migration lock'];
+	const tables = ['migration', 'migration lock', 'migration status'];
 	const where = tables.map((tableName) => `name = '${tableName}'`).join(' OR ');
 	const result = await tx.tableList(where);
 	return result.rows.length === tables.length;

--- a/src/server-glue/module.ts
+++ b/src/server-glue/module.ts
@@ -8,6 +8,7 @@ import * as migrator from '../migrator/sync';
 import * as migratorUtils from '../migrator/utils';
 
 import * as sbvrUtils from '../sbvr-api/sbvr-utils';
+import { PINEJS_ADVISORY_LOCK } from '../config-loader/env';
 
 export * as dbModule from '../database-layer/db';
 export { PinejsSessionStore } from '../pinejs-session-store/pinejs-session-store';
@@ -52,6 +53,11 @@ export const init = async <T extends string>(
 ): Promise<ReturnType<typeof configLoader.setup>> => {
 	try {
 		const db = dbModule.connect(databaseOptions);
+		// register a pinejs unique lock namespace
+		dbModule.registerTransactionLockNamespace(
+			PINEJS_ADVISORY_LOCK.namespaceKey,
+			PINEJS_ADVISORY_LOCK.namespaceId,
+		);
 		await sbvrUtils.setup(app, db);
 		const cfgLoader = await configLoader.setup(app);
 		await cfgLoader.loadConfig(migrator.config);

--- a/test/fixtures/03-async-migrator/08-01-async-lock-taker.ts
+++ b/test/fixtures/03-async-migrator/08-01-async-lock-taker.ts
@@ -1,0 +1,55 @@
+import type { ConfigLoader } from '../../../src/server-glue/module';
+
+const apiRoot = 'example';
+const modelName = 'example';
+const modelFile = __dirname + '/example.sbvr';
+
+const asyncSpammer = {
+	asyncFn: async (tx: any) => {
+		const staticSql = `\
+		select pg_sleep(1);
+	`;
+		return await tx.executeSql(staticSql);
+	},
+	syncFn: async (tx: any) => {
+		const staticSql = `\
+		select pg_sleep(1);
+	`;
+
+		await tx.executeSql(staticSql);
+	},
+	asyncBatchSize: 10,
+	delayMS: 50, // aggressive small delays
+	backoffDelayMS: 50, // aggressive small delays
+	errorThreshold: 15,
+	finalize: false,
+	type: 'async',
+};
+
+const asyncSpammers: { [key: string]: {} } = {};
+
+for (let spammerKey = 2; spammerKey < 20; spammerKey++) {
+	const key: string = spammerKey.toString().padStart(4, '0') + '-async-spammer';
+	asyncSpammers[key] = asyncSpammer;
+}
+
+export default {
+	models: [
+		{
+			modelName,
+			modelFile,
+			apiRoot,
+			migrations: {
+				sync: {},
+				async: asyncSpammers,
+			},
+		},
+	],
+	users: [
+		{
+			username: 'guest',
+			password: ' ',
+			permissions: ['resource.all'],
+		},
+	],
+} as ConfigLoader.Config;

--- a/test/fixtures/03-async-migrator/08-02-sync-lock-starvation.ts
+++ b/test/fixtures/03-async-migrator/08-02-sync-lock-starvation.ts
@@ -1,0 +1,40 @@
+import type { ConfigLoader } from '../../../src/server-glue/module';
+
+const apiRoot = 'example';
+const modelName = 'example';
+const modelFile = __dirname + '/example.sbvr';
+
+export default {
+	models: [
+		{
+			modelName,
+			modelFile,
+			apiRoot,
+			migrations: {
+				async: {},
+				sync: {
+					'1000-another-data-insert': async (tx) => {
+						await tx.executeSql(`
+					INSERT INTO "device" (
+						"id", "name", "note", "type"
+					)
+					SELECT
+						i as "id",
+						CONCAT('a','b',trim(to_char(i,'0000000'))) as "name",
+						NULL as "note",
+						CONCAT('b','b',trim(to_char(i,'0000000'))) as "type"
+					FROM generate_series(21, 30) s(i);	
+					`);
+					},
+				},
+			},
+		},
+	],
+	users: [
+		{
+			username: 'guest',
+			password: ' ',
+			permissions: ['resource.all'],
+		},
+	],
+} as ConfigLoader.Config;


### PR DESCRIPTION
Avoid starvation of sync migrations while
aggressive async migrations take the model lock
over and over again.

Change-type: minor
Signed-off-by: fisehara <harald@balena.io>