### PR TITLE
db: Make the base getTxLevelLock blocking by default

### DIFF
--- a/src/database-layer/db.ts
+++ b/src/database-layer/db.ts
@@ -400,7 +400,7 @@ export abstract class Tx {
 	public async getTxLevelLock(
 		_namespaceKey: string,
 		_key: number,
-		_blocking: boolean,
+		_blocking: boolean = true,
 	): Promise<boolean> {
 		throw new Error(
 			'The getTxLevelLock method is not implemented for the current engine.',


### PR DESCRIPTION
That's already how it works b/c the only concrete implementation default to true, so this is more as a way to make the base class typings mark this as an optional parameter having a default value.
Otherwise users would get a  TS error after updating.

Change-type: patch
See: https://github.com/balena-io/open-balena-api/actions/runs/4004587439/jobs/6873921096