### PR TITLE
Fix resourceName to resourceName native translation

### DIFF
--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -1047,7 +1047,9 @@ const getBoundConstrainedMemoizer = memoizeWeak(
 									permissionsLookup,
 									permissions,
 									vocabulary,
-									sqlNameToODataName(permissionsTable.name),
+									sqlNameToODataName(
+										permissionsTable.modifyName ?? permissionsTable.name,
+									),
 								),
 							);
 


### PR DESCRIPTION
Permissions lookup need to know the modifyName if the resource needs translations for looking up the permissions from the destination permissions table

Change-type: patch