### PR TITLE
Add scheduled tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "lodash": "^4.17.21",
     "memoizee": "^0.4.15",
     "pinejs-client-core": "^6.13.0",
+    "node-schedule": "^2.1.1",
     "randomstring": "^1.2.3",
     "typed-error": "^3.2.2"
   },
@@ -71,6 +72,7 @@
     "@types/mocha": "^10.0.1",
     "@types/on-finished": "^2.3.1",
     "@types/request": "^2.48.8",
+    "@types/node-schedule": "^2.1.0",
     "@types/supertest": "^2.0.12",
     "@types/terser-webpack-plugin": "^5.2.0",
     "@types/type-is": "^1.6.3",

--- a/src/config-loader/env.ts
+++ b/src/config-loader/env.ts
@@ -146,3 +146,9 @@ export const migrator = {
 	 */
 	asyncMigrationIsEnabled: boolVar('PINEJS_ASYNC_MIGRATION_ENABLED', true),
 };
+
+export const tasks = {
+	pollIntervalMS: process.env.TASKS_POLL_INTERVAL_MS
+		? parseInt(process.env.TASKS_POLL_INTERVAL_MS, 10)
+		: 2000,
+};

--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -42,6 +42,7 @@ import { generateODataMetadata } from '../odata-metadata/odata-metadata-generato
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const devModel = require('./dev.sbvr');
+import * as tasks from './tasks';
 import * as permissions from './permissions';
 import {
 	BadRequestError,
@@ -77,6 +78,7 @@ export {
 	addPureHook,
 	addSideEffectHook,
 } from './hooks';
+export { addTaskHandler } from './tasks';
 
 import memoizeWeak = require('memoizee/weak');
 import * as controlFlow from './control-flow';
@@ -1944,6 +1946,7 @@ export const executeStandardModels = async (tx: Db.Tx): Promise<void> => {
 			},
 		});
 		await executeModels(tx, permissions.config.models);
+		await executeModels(tx, tasks.config.models);
 		console.info('Successfully executed standard models.');
 	} catch (err: any) {
 		console.error('Failed to execute standard models.', err);
@@ -1960,6 +1963,7 @@ export const setup = async (
 		await db.transaction(async (tx) => {
 			await executeStandardModels(tx);
 			await permissions.setup();
+			await tasks.setup(tx);
 		});
 	} catch (err: any) {
 		console.error('Could not execute standard models', err);

--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -1965,6 +1965,7 @@ export const setup = async (
 			await permissions.setup();
 			await tasks.setup(tx);
 		});
+		await tasks.postSetup(db);
 	} catch (err: any) {
 		console.error('Could not execute standard models', err);
 		process.exit(1);

--- a/src/sbvr-api/tasks.sbvr
+++ b/src/sbvr-api/tasks.sbvr
@@ -1,0 +1,41 @@
+Vocabulary: tasks
+
+Term: key
+	Concept Type: Short Text (Type)
+Term: handler
+	Concept Type: Short Text (Type)
+Term: actor
+	Concept Type: Integer (Type)
+Term: parameter set
+	Concept Type: JSON (Type)
+Term: start time
+	Concept Type: Date Time (Type)
+Term: retry limit
+	Concept Type: Integer (Type)
+Term: error count
+	Concept Type: Integer (Type)
+Term: last error
+	Concept Type: Short Text (Type)
+Term: status
+	Concept Type: Short Text (Type)
+
+Term: task
+Fact Type: task has key
+	Necessity: each task has exactly one key
+Fact Type: task is executed by actor
+	Necessity: each task is executed by exactly one actor
+Fact Type: task is executed by handler
+	Necessity: each task is executed by exactly one handler
+Fact Type: task is executed with parameter set
+	Necessity: each task is executed with exactly one parameter set
+Fact Type: task has start time
+	Necessity: each task has at most one start time
+Fact Type: task has retry limit
+	Necessity: each task has exactly one retry limit
+Fact Type: task has error count
+	Necessity: each task has at most one error count
+Fact Type: task has last error
+	Necessity: each task has at most one last error
+Fact Type: task has status
+	Necessity: each task has exactly one status
+	Definition: "pending" or "success" or "failed"

--- a/src/sbvr-api/tasks.sbvr
+++ b/src/sbvr-api/tasks.sbvr
@@ -1,41 +1,77 @@
 Vocabulary: tasks
 
-Term: key
-	Concept Type: Short Text (Type)
-Term: handler
-	Concept Type: Short Text (Type)
 Term: actor
 	Concept Type: Integer (Type)
-Term: parameter set
-	Concept Type: JSON (Type)
-Term: start time
+Term: cron expression
+	Concept Type: Short Text (Type)
+Term: end time
 	Concept Type: Date Time (Type)
-Term: retry limit
-	Concept Type: Integer (Type)
+Term: error
+	Concept Type: Short Text (Type)
 Term: error count
 	Concept Type: Integer (Type)
+Term: handler
+	Concept Type: Short Text (Type)
+Term: key
+	Concept Type: Short Text (Type)
 Term: last error
 	Concept Type: Short Text (Type)
+Term: last run time
+	Concept Type: Date Time (Type)
+Term: model name
+	Concept Type: Short Text (Type)
+Term: parameter set
+	Concept Type: JSON (Type)
+Term: priority
+	Concept Type: Integer (Type)
+Term: retry limit
+	Concept Type: Integer (Type)
+Term: run count
+	Concept Type: Integer (Type)
+Term: start time
+	Concept Type: Date Time (Type)
 Term: status
 	Concept Type: Short Text (Type)
 
 Term: task
-Fact Type: task has key
-	Necessity: each task has exactly one key
-Fact Type: task is executed by actor
-	Necessity: each task is executed by exactly one actor
+Fact Type: task has error count
+	Necessity: each task has exactly one error count
 Fact Type: task is executed by handler
 	Necessity: each task is executed by exactly one handler
 Fact Type: task is executed with parameter set
-	Necessity: each task is executed with exactly one parameter set
-Fact Type: task has start time
-	Necessity: each task has at most one start time
-Fact Type: task has retry limit
-	Necessity: each task has exactly one retry limit
-Fact Type: task has error count
-	Necessity: each task has at most one error count
+	Necessity: each task is executed with at most one parameter set
+Fact Type: task is for model name
+	Necessity: each task is for exactly one model name
+Fact Type: task is scheduled by actor
+	Necessity: each task is scheduled by exactly one actor
+Fact Type: task is scheduled with cron expression
+	Necessity: each task is scheduled with at most one cron expression
+Fact Type: task has key
+	Necessity: each task has exactly one key
 Fact Type: task has last error
 	Necessity: each task has at most one last error
-Fact Type: task has status
-	Necessity: each task has exactly one status
-	Definition: "pending" or "success" or "failed"
+Fact Type: task has priority
+	Necessity: each task has exactly one priority
+	Necessity: each task has a priority that is greater than or equal to 0
+Fact Type: task has retry limit
+	Necessity: each task has exactly one retry limit
+Fact Type: task has run count
+	Necessity: each task has exactly one run count
+Fact Type: task has start time
+	Necessity: each task has exactly one start time
+Fact Type: task is complete
+
+Term: task run
+Fact Type: task run has error
+	Necessity: each task run has at most one error
+Fact Type: task run is for task
+	Synonymous Form: task was executed by task run
+	Necessity: each task run is for exactly one task
+	Reference Type: informative
+Fact Type: task run has start time
+	Necessity: each task run has exactly one start time
+Fact Type: task run has end time
+	Necessity: each task run has at most one end time
+Fact Type: task run has status
+	Necessity: each task run has exactly one status
+	Definition: "running" or "success" or "failed"

--- a/src/sbvr-api/tasks.ts
+++ b/src/sbvr-api/tasks.ts
@@ -4,8 +4,8 @@ import { AnyObject } from 'pinejs-client-core';
 import * as errors from './errors';
 import { addPureHook } from './hooks';
 import * as sbvrUtils from './sbvr-utils';
+import { tasks as tasksEnv } from '../config-loader/env';
 import type * as Db from '../database-layer/db';
-import { permissions } from '../server-glue/module';
 
 const apiRoot = 'tasks';
 const DEFAULT_RETRY_LIMIT = 10;
@@ -15,15 +15,32 @@ const modelText: string = require(`./${apiRoot}.sbvr`);
 
 interface Task {
 	id: number;
-	key: string;
+	error_count: number;
 	is_executed_by__handler: string;
 	is_executed_with__parameter_set: any;
+	is_for__model_name: string;
+	is_scheduled_by__actor: string;
+	is_scheduled_with__cron_expression?: string;
 	start_time: Date;
-	retry_limit: number;
-	error_count: number;
+	key: string;
 	last_error?: string;
+	priority: number;
+	retry_limit: number;
+	run_count: number;
+	is_complete: boolean;
+}
+
+interface TaskRun {
+	id: number;
+	end_time: Date;
+	error?: string;
+	is_for__task: {
+		__id: number;
+	};
+	start_time: Date;
 	status: string;
 }
+
 interface TaskHandler {
 	parameters: {
 		[key: string]: string;
@@ -56,8 +73,13 @@ function getActor(req: sbvrUtils.HookReq): number {
  * Create and return client for internal use.
  * @returns A /tasks pine client
  */
-function getClient(): sbvrUtils.PinejsClient {
-	return new sbvrUtils.PinejsClient(`/${apiRoot}/`) as sbvrUtils.LoggingClient;
+function getClient(tx: Db.Tx): sbvrUtils.PinejsClient {
+	return new sbvrUtils.PinejsClient({
+		apiPrefix: `/${apiRoot}/`,
+		passthrough: {
+			tx,
+		},
+	}) as sbvrUtils.LoggingClient;
 }
 
 /**
@@ -65,12 +87,16 @@ function getClient(): sbvrUtils.PinejsClient {
  * @param values - Request values to validate
  */
 function validate(values: AnyObject) {
-	// Assert that the provided date is in the future.
+	// Assert that the provided start time is at least a minute in the future.
 	if (values.start_time == null) {
 		throw new errors.BadRequestError('Must specify a start time for the task');
 	}
-	if (new Date(values.start_time).getTime() <= new Date().getTime()) {
-		throw new errors.BadRequestError('Task start time must be in the future');
+	const now = new Date(new Date().getTime() + tasksEnv.pollIntervalMS);
+	const startTime = new Date(values.start_time);
+	if (startTime < now) {
+		throw new errors.BadRequestError(
+			`Task start time must be greater than ${tasksEnv.pollIntervalMS} milliseconds in the future`,
+		);
 	}
 
 	// Assert that the requested handler exists.
@@ -86,11 +112,12 @@ function validate(values: AnyObject) {
 	// Assert that the requested parameters match the handler.
 	const handler = taskHandlers[values.is_executed_by__handler];
 	const parameterSet = values.is_executed_with__parameter_set;
-	if (handler.parameters != null && parameterSet == null) {
+	if (Object.keys(handler.parameters).length > 0 && parameterSet == null) {
 		throw new errors.BadRequestError(
 			`Must specify parameters to execute task handler "${values.is_executed_by__handler}"`,
 		);
 	}
+
 	if (parameterSet != null) {
 		for (const parameterName of Object.keys(parameterSet)) {
 			if (handler.parameters[parameterName] == null) {
@@ -113,48 +140,92 @@ function validate(values: AnyObject) {
  * Execute a task, retrying and updating as necessary.
  * @param task - Task to execute
  */
-async function execute(task: Task): Promise<void> {
-	const client = getClient();
-	try {
-		await taskHandlers[task.is_executed_by__handler].callback(
-			task.is_executed_with__parameter_set,
-		);
+async function execute(task: Task, db: Db.Database): Promise<void> {
+	await db.transaction(async (tx) => {
+		const client = getClient(tx);
 
-		// Execution was a success so update the task as such.
-		await client.patch({
-			resource: 'task',
-			id: task.id,
+		// Create task run record.
+		const taskRun = (await client.post({
+			resource: 'task_run',
 			body: {
-				status: 'success',
+				is_for__task: task.id,
+				start_time: new Date(),
+				status: 'running',
 			},
-		});
-	} catch (err: any) {
-		// Re-schedule if the retry limit has not been reached.
-		task.error_count++;
-		if (task.error_count < task.retry_limit) {
+		})) as TaskRun;
+
+		try {
+			await taskHandlers[task.is_executed_by__handler].callback({
+				...task.is_executed_with__parameter_set,
+				tx,
+			});
+
+			// Execution was a success so update the task and task_run as such.
+			await Promise.all([
+				client.patch({
+					resource: 'task_run',
+					id: taskRun.id,
+					body: {
+						end_time: new Date(),
+						status: 'success',
+					},
+				}),
+				client.patch({
+					resource: 'task',
+					id: task.id,
+					body: {
+						run_count: task.run_count + 1,
+						is_complete: true,
+					},
+				}),
+			]);
+		} catch (err: any) {
 			await client.patch({
-				resource: 'task',
-				id: task.id,
+				resource: 'task_run',
+				id: taskRun.id,
 				body: {
-					error_count: task.error_count,
-					last_error: err.message,
-					// TODO: Improve backoff time logic.
-					start_time: new Date(Date.now() + 10000 * task.error_count),
+					end_time: new Date(),
+					status: 'failed',
+					error: err.message,
 				},
 			});
-		} else {
-			// Execution failed so update the task as such.
+
+			// Update the main task resource.
+			// Mark as failed if all attempts have been exhausted or re-schedule.
+			const body: AnyObject = {
+				error_count: task.error_count + 1,
+				last_error: err.message,
+				run_count: task.run_count + 1,
+			};
+			if (body.error_count < task.retry_limit) {
+				body.start_time = calculateNextAttemptDate(
+					task.start_time,
+					task.run_count,
+				);
+				console.log('next start_time:', body.start_time);
+			} else {
+				body.is_complete = true;
+			}
 			await client.patch({
 				resource: 'task',
 				id: task.id,
-				body: {
-					status: 'failed',
-					error_count: task.error_count,
-					last_error: err.message,
-				},
+				body,
 			});
 		}
-	}
+	});
+}
+
+// Calculate a date for the next attempt using the following exponential backoff formula:
+//  nextAttemptDate = max(now, previousStartTime) + e^min(attempt, 10) seconds
+function calculateNextAttemptDate(
+	previousStartTime: Date,
+	attempt: number,
+): Date {
+	const from = new Date(
+		Math.max(new Date().getTime(), previousStartTime.getTime()),
+	);
+	const exponent = Math.exp(Math.min(attempt, 10));
+	return new Date(from.getTime() + exponent * 1000);
 }
 
 export const config = {
@@ -168,30 +239,24 @@ export const config = {
 	] as sbvrUtils.ExecutableModel[],
 };
 
-export const setup = async (tx: Db.Tx) => {
+export const setup = async () => {
 	// Validate and schedule new tasks for future execution.
 	addPureHook('POST', apiRoot, 'task', {
 		POSTPARSE: async ({ req, request }) => {
 			// Set the actor.
-			request.values.is_executed_by__actor = getActor(req);
+			request.values.is_scheduled_by__actor = getActor(req);
 
 			// Set defaults.
+			request.values.error_count = 0;
 			request.values.status = 'pending';
 			request.values.retry_count = 0;
+			request.values.run_count = 0;
+			request.values.is_complete = false;
 			request.values.retry_limit ??= DEFAULT_RETRY_LIMIT;
-			request.values.error_count = 0;
+			request.values.priority ??= 1;
 
 			// Validate the task.
 			validate(request.values);
-		},
-		POSTRUN: async ({ api, result }) => {
-			const task = (await api.get({
-				resource: 'task',
-				id: result,
-			})) as Task;
-			nodeSchedule.scheduleJob(`${task.id}`, task.start_time, async () => {
-				await execute(task);
-			});
 		},
 	});
 
@@ -204,34 +269,28 @@ export const setup = async (tx: Db.Tx) => {
 			}
 		},
 	});
+};
 
-	// Find and re-schedule/execute pending tasks on startup.
-	const client = getClient();
-	const tasks = (await client.get({
-		resource: 'task',
-		passthrough: {
-			req: permissions.root,
-			tx,
-		},
-		options: {
-			$filter: {
-				status: 'pending',
-			},
-		},
-	})) as Task[];
-	const now = new Date();
-	for (const task of tasks) {
-		if (task.start_time.getTime() < now.getTime()) {
-			// Execute pending tasks that should have already been executed.
-			await execute(task);
-		} else if (task.start_time.getTime() > now.getTime()) {
-			// Re-schedule pending tasks that have not yet been executed.
-			nodeSchedule.scheduleJob(task.key, task.start_time, async () => {
-				await execute(task);
+let currentTask: string | undefined;
+export async function postSetup(db: Db.Database): Promise<void> {
+	setInterval(async () => {
+		if (currentTask == null) {
+			await db.transaction(async (tx) => {
+				const result = await tx.executeSql(
+					'SELECT t."id", t."error count" AS error_count, t."is executed by-handler" AS is_executed_by__handler, t."is executed with-parameter set" AS is_executed_with__parameter_set, t."is scheduled with-cron expression" AS is_scheduled_with__cron_expression, t."start time" AS start_time, t."key", t."retry limit" as retry_limit, t."run count" AS run_count FROM task AS t WHERE t."is complete"=false AND t."start time" > NOW() ORDER BY t."priority" DESC, t."start time" ASC LIMIT 1 FOR UPDATE SKIP LOCKED',
+				);
+				if (result.rows.length > 0) {
+					const task = result.rows[0] as Task;
+					currentTask = task.key;
+					nodeSchedule.scheduleJob(task.start_time, async () => {
+						await execute(task, db);
+						currentTask = undefined;
+					});
+				}
 			});
 		}
-	}
-};
+	}, tasksEnv.pollIntervalMS);
+}
 
 /**
  * Register a new task handler.
@@ -241,9 +300,9 @@ export const setup = async (tx: Db.Tx) => {
  *
  * @example
  * addTaskHandler('myTaskHandler', {
- *     message: 'string',
+ *		message: 'string',
  * }, async ({ message }) => {
- *    console.log(message);
+ *		console.log(message);
  * });
  */
 export const addTaskHandler = (

--- a/src/sbvr-api/tasks.ts
+++ b/src/sbvr-api/tasks.ts
@@ -1,0 +1,261 @@
+import * as nodeSchedule from 'node-schedule';
+import { AnyObject } from 'pinejs-client-core';
+
+import * as errors from './errors';
+import { addPureHook } from './hooks';
+import * as sbvrUtils from './sbvr-utils';
+import type * as Db from '../database-layer/db';
+import { permissions } from '../server-glue/module';
+
+const apiRoot = 'tasks';
+const DEFAULT_RETRY_LIMIT = 10;
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const modelText: string = require(`./${apiRoot}.sbvr`);
+
+interface Task {
+	id: number;
+	key: string;
+	is_executed_by__handler: string;
+	is_executed_with__parameter_set: any;
+	start_time: Date;
+	retry_limit: number;
+	error_count: number;
+	last_error?: string;
+	status: string;
+}
+interface TaskHandler {
+	parameters: {
+		[key: string]: string;
+	};
+	callback: (parameterSet: any) => Promise<void>;
+}
+
+// TODO: Need to scope task handlers to model?
+const taskHandlers: {
+	[name: string]: TaskHandler;
+} = {};
+
+/**
+ * Get and return actor from hook request object.
+ * @param req - Hook request object
+ * @returns Actor ID
+ * @throws BadRequestError if actor is missing
+ */
+function getActor(req: sbvrUtils.HookReq): number {
+	const actor = req.user?.actor ?? req.apiKey?.actor;
+	if (actor == null) {
+		throw new errors.BadRequestError(
+			'Scheduling task with missing actor on req is not allowed',
+		);
+	}
+	return actor;
+}
+
+/**
+ * Create and return client for internal use.
+ * @returns A /tasks pine client
+ */
+function getClient(): sbvrUtils.PinejsClient {
+	return new sbvrUtils.PinejsClient(`/${apiRoot}/`) as sbvrUtils.LoggingClient;
+}
+
+/**
+ * Validates a task.
+ * @param values - Request values to validate
+ */
+function validate(values: AnyObject) {
+	// Assert that the provided date is in the future.
+	if (values.start_time == null) {
+		throw new errors.BadRequestError('Must specify a start time for the task');
+	}
+	if (new Date(values.start_time).getTime() <= new Date().getTime()) {
+		throw new errors.BadRequestError('Task start time must be in the future');
+	}
+
+	// Assert that the requested handler exists.
+	if (values.is_executed_by__handler == null) {
+		throw new errors.BadRequestError(`Must specify a task handler to execute`);
+	}
+	if (taskHandlers[values.is_executed_by__handler] == null) {
+		throw new errors.BadRequestError(
+			`No task handler with name ${values.is_executed_by__handler} registered`,
+		);
+	}
+
+	// Assert that the requested parameters match the handler.
+	const handler = taskHandlers[values.is_executed_by__handler];
+	const parameterSet = values.is_executed_with__parameter_set;
+	if (handler.parameters != null && parameterSet == null) {
+		throw new errors.BadRequestError(
+			`Must specify parameters to execute task handler "${values.is_executed_by__handler}"`,
+		);
+	}
+	if (parameterSet != null) {
+		for (const parameterName of Object.keys(parameterSet)) {
+			if (handler.parameters[parameterName] == null) {
+				throw new errors.BadRequestError(
+					`Task handler "${values.is_executed_by__handler}" does not accept parameter "${parameterName}"`,
+				);
+			}
+			if (
+				typeof parameterSet[parameterName] !== handler.parameters[parameterName]
+			) {
+				throw new errors.BadRequestError(
+					`Task handler "${values.is_executed_by__handler}" parameter "${parameterName}" must be of type "${handler.parameters[parameterName]}"`,
+				);
+			}
+		}
+	}
+}
+
+/**
+ * Execute a task, retrying and updating as necessary.
+ * @param task - Task to execute
+ */
+async function execute(task: Task): Promise<void> {
+	const client = getClient();
+	try {
+		await taskHandlers[task.is_executed_by__handler].callback(
+			task.is_executed_with__parameter_set,
+		);
+
+		// Execution was a success so update the task as such.
+		await client.patch({
+			resource: 'task',
+			id: task.id,
+			body: {
+				status: 'success',
+			},
+		});
+	} catch (err: any) {
+		// Re-schedule if the retry limit has not been reached.
+		task.error_count++;
+		if (task.error_count < task.retry_limit) {
+			await client.patch({
+				resource: 'task',
+				id: task.id,
+				body: {
+					error_count: task.error_count,
+					last_error: err.message,
+					// TODO: Improve backoff time logic.
+					start_time: new Date(Date.now() + 10000 * task.error_count),
+				},
+			});
+		} else {
+			// Execution failed so update the task as such.
+			await client.patch({
+				resource: 'task',
+				id: task.id,
+				body: {
+					status: 'failed',
+					error_count: task.error_count,
+					last_error: err.message,
+				},
+			});
+		}
+	}
+}
+
+export const config = {
+	models: [
+		{
+			apiRoot,
+			modelText,
+			customServerCode: exports,
+			migrations: {},
+		},
+	] as sbvrUtils.ExecutableModel[],
+};
+
+export const setup = async (tx: Db.Tx) => {
+	// Validate and schedule new tasks for future execution.
+	addPureHook('POST', apiRoot, 'task', {
+		POSTPARSE: async ({ req, request }) => {
+			// Set the actor.
+			request.values.is_executed_by__actor = getActor(req);
+
+			// Set defaults.
+			request.values.status = 'pending';
+			request.values.retry_count = 0;
+			request.values.retry_limit ??= DEFAULT_RETRY_LIMIT;
+			request.values.error_count = 0;
+
+			// Validate the task.
+			validate(request.values);
+		},
+		POSTRUN: async ({ api, result }) => {
+			const task = (await api.get({
+				resource: 'task',
+				id: result,
+			})) as Task;
+			nodeSchedule.scheduleJob(`${task.id}`, task.start_time, async () => {
+				await execute(task);
+			});
+		},
+	});
+
+	// Cancel tasks when they are deleted.
+	addPureHook('DELETE', apiRoot, 'task', {
+		POSTRUN: async (args) => {
+			const affectedIds = await sbvrUtils.getAffectedIds(args);
+			for (const id of affectedIds) {
+				nodeSchedule.cancelJob(`${id}`);
+			}
+		},
+	});
+
+	// Find and re-schedule/execute pending tasks on startup.
+	const client = getClient();
+	const tasks = (await client.get({
+		resource: 'task',
+		passthrough: {
+			req: permissions.root,
+			tx,
+		},
+		options: {
+			$filter: {
+				status: 'pending',
+			},
+		},
+	})) as Task[];
+	const now = new Date();
+	for (const task of tasks) {
+		if (task.start_time.getTime() < now.getTime()) {
+			// Execute pending tasks that should have already been executed.
+			await execute(task);
+		} else if (task.start_time.getTime() > now.getTime()) {
+			// Re-schedule pending tasks that have not yet been executed.
+			nodeSchedule.scheduleJob(task.key, task.start_time, async () => {
+				await execute(task);
+			});
+		}
+	}
+};
+
+/**
+ * Register a new task handler.
+ * @param name - task handler unique name
+ * @param parameters - task handler parameters definition
+ * @param callback - task handler callback to execute
+ *
+ * @example
+ * addTaskHandler('myTaskHandler', {
+ *     message: 'string',
+ * }, async ({ message }) => {
+ *    console.log(message);
+ * });
+ */
+export const addTaskHandler = (
+	name: string,
+	parameters: TaskHandler['parameters'],
+	callback: TaskHandler['callback'],
+): void => {
+	if (taskHandlers[name] != null) {
+		throw new Error(`Task handler with name "${name}" already registered`);
+	}
+	taskHandlers[name] = {
+		parameters,
+		callback,
+	};
+};

--- a/src/server-glue/module.ts
+++ b/src/server-glue/module.ts
@@ -19,6 +19,7 @@ export * as env from '../config-loader/env';
 export * as types from '../sbvr-api/common-types';
 export * as hooks from '../sbvr-api/hooks';
 export * as webResourceHandler from '../webresource-handler';
+export * as tasks from '../sbvr-api/tasks';
 export type { configLoader as ConfigLoader };
 export type { migratorUtils as Migrator };
 

--- a/test/07-tasks.test.ts
+++ b/test/07-tasks.test.ts
@@ -1,0 +1,82 @@
+import { setTimeout } from 'node:timers/promises';
+import { randomUUID } from 'node:crypto';
+import { PineTest } from 'pinejs-client-supertest';
+import * as supertest from 'supertest';
+import { testInit, testDeInit, testLocalServer } from './lib/test-init';
+
+const configPath = __dirname + '/fixtures/07-tasks/config';
+const taskHandlersPath = __dirname + '/fixtures/07-tasks/task-handlers';
+
+async function waitFor(checkFn: () => Promise<boolean>): Promise<void> {
+	const maxCount = 10;
+	for (let i = 1; i <= maxCount; i++) {
+		console.log(`Waiting (${i}/${maxCount})...`);
+		await setTimeout(250);
+		if (await checkFn()) {
+			return;
+		}
+	}
+	throw new Error('waitFor timed out');
+}
+
+describe('07 task tests', function () {
+	let pineServer: Awaited<ReturnType<typeof testInit>>;
+	let pineTest: PineTest;
+	let apikey: string;
+	before(async () => {
+		pineServer = await testInit({
+			configPath,
+			taskHandlersPath,
+		});
+		pineTest = new PineTest({}, { app: testLocalServer });
+
+		// Create an API key for future use.
+		apikey = randomUUID();
+		await pineTest
+			.post({
+				apiPrefix: 'Auth/',
+				resource: 'api_key',
+				body: {
+					key: apikey,
+					is_of__actor: 1,
+					permissions: [],
+				},
+			})
+			.expect(201);
+	});
+
+	after(async () => {
+		testDeInit(pineServer);
+	});
+
+	describe('tasks', () => {
+		it('create a task', async () => {
+			// Create a task using the token.
+			const name = randomUUID();
+			const now = new Date();
+			await pineTest
+				.post({
+					apiPrefix: 'tasks/',
+					resource: 'task',
+					body: {
+						key: 'foobar-1',
+						is_executed_by__handler: 'foobar',
+						is_executed_with__parameter_set: {
+							name,
+							type: randomUUID(),
+						},
+						start_time: new Date(now.getTime() + 500),
+						apikey,
+					},
+				})
+				.expect(201);
+
+			await waitFor(async () => {
+				const { body } = await supertest(testLocalServer)
+					.get(`/example/device?$filter=name eq '${name}'`)
+					.expect(200);
+				return body.d.length === 1;
+			});
+		});
+	});
+});

--- a/test/07-tasks.test.ts
+++ b/test/07-tasks.test.ts
@@ -1,22 +1,29 @@
-import { setTimeout } from 'node:timers/promises';
+import { expect } from 'chai';
 import { randomUUID } from 'node:crypto';
+import { setTimeout } from 'node:timers/promises';
 import { PineTest } from 'pinejs-client-supertest';
-import * as supertest from 'supertest';
 import { testInit, testDeInit, testLocalServer } from './lib/test-init';
+import { tasks as tasksEnv } from '../src/config-loader/env';
 
 const configPath = __dirname + '/fixtures/07-tasks/config';
 const taskHandlersPath = __dirname + '/fixtures/07-tasks/task-handlers';
 
+// Wait for a condition to be true, or throw an error if it doesn't happen in time.
 async function waitFor(checkFn: () => Promise<boolean>): Promise<void> {
 	const maxCount = 10;
 	for (let i = 1; i <= maxCount; i++) {
 		console.log(`Waiting (${i}/${maxCount})...`);
-		await setTimeout(250);
+		await setTimeout(tasksEnv.pollIntervalMS);
 		if (await checkFn()) {
 			return;
 		}
 	}
 	throw new Error('waitFor timed out');
+}
+
+// Calculate number of milliseconds in the future to schedule a task.
+function getFutureMS(): number {
+	return tasksEnv.pollIntervalMS + tasksEnv.pollIntervalMS / 10;
 }
 
 describe('07 task tests', function () {
@@ -26,9 +33,17 @@ describe('07 task tests', function () {
 	before(async () => {
 		pineServer = await testInit({
 			configPath,
+			deleteDb: true,
 			taskHandlersPath,
 		});
-		pineTest = new PineTest({}, { app: testLocalServer });
+		pineTest = new PineTest(
+			{
+				apiPrefix: 'tasks/',
+			},
+			{
+				app: testLocalServer,
+			},
+		);
 
 		// Create an API key for future use.
 		apikey = randomUUID();
@@ -50,33 +65,198 @@ describe('07 task tests', function () {
 	});
 
 	describe('tasks', () => {
-		it('create a task', async () => {
-			// Create a task using the token.
+		it('should execute with specified handler and parameters', async () => {
+			// Create a task to create a new device record in 500ms.
 			const name = randomUUID();
-			const now = new Date();
-			await pineTest
+			const { body: task } = await pineTest
 				.post({
-					apiPrefix: 'tasks/',
 					resource: 'task',
 					body: {
-						key: 'foobar-1',
-						is_executed_by__handler: 'foobar',
+						is_for__model_name: 'example',
+						key: randomUUID(),
+						is_executed_by__handler: 'create_device',
 						is_executed_with__parameter_set: {
 							name,
 							type: randomUUID(),
 						},
-						start_time: new Date(now.getTime() + 500),
+						start_time: new Date(new Date().getTime() + getFutureMS()),
 						apikey,
 					},
 				})
 				.expect(201);
 
+			// Assert the expected record was created.
 			await waitFor(async () => {
-				const { body } = await supertest(testLocalServer)
-					.get(`/example/device?$filter=name eq '${name}'`)
+				const { body: devices } = await pineTest
+					.get({
+						apiPrefix: 'example/',
+						resource: 'device',
+						options: {
+							$filter: {
+								name,
+							},
+						},
+					})
 					.expect(200);
-				return body.d.length === 1;
+				return devices.length === 1;
 			});
+
+			// Assert the expected task_run record exists.
+			const { body: taskRuns } = await pineTest.get({
+				resource: 'task_run',
+				options: {
+					$select: ['end_time', 'error', 'start_time', 'status'],
+					$filter: {
+						is_for__task: task.id,
+					},
+				},
+			});
+			expect(taskRuns.length).to.equal(1);
+			expect(new Date(taskRuns[0].end_time).getTime()).to.be.greaterThan(
+				new Date(taskRuns[0].start_time).getTime(),
+			);
+			expect(taskRuns[0].error).to.equal(null);
+			expect(taskRuns[0].status).to.equal('success');
+
+			// Assert the task record was updated as expected.
+			const { body: updatedTask } = await pineTest
+				.get({
+					resource: 'task',
+					id: task.id,
+					options: {
+						$select: [
+							'error_count',
+							'is_scheduled_by__actor',
+							'last_error',
+							'run_count',
+							'start_time',
+							'is_complete',
+						],
+					},
+				})
+				.expect(200);
+			expect(new Date(updatedTask.start_time)).to.be.instanceOf(Date);
+			expect(updatedTask.error_count).to.equal(0);
+			expect(updatedTask.is_scheduled_by__actor).to.equal(1);
+			expect(updatedTask.last_error).to.equal(null);
+			expect(updatedTask.run_count).to.equal(1);
+			expect(updatedTask.is_complete).to.equal(true);
+		});
+
+		it('should cancel scheduled execution on deletion', async () => {
+			// Create a task to create a record in a few seconds, but delete the task before it executes.
+			const futureMS = getFutureMS();
+			const name = randomUUID();
+			const { body: task } = await pineTest
+				.post({
+					resource: 'task',
+					body: {
+						is_for__model_name: 'example',
+						key: randomUUID(),
+						is_executed_by__handler: 'create_device',
+						is_executed_with__parameter_set: {
+							name,
+							type: randomUUID(),
+						},
+						start_time: new Date(new Date().getTime() + futureMS),
+						apikey,
+					},
+				})
+				.expect(201);
+
+			// Delete the task.
+			await pineTest
+				.delete({
+					resource: 'task',
+					id: task.id,
+				})
+				.expect(200);
+
+			// Wait until when the task should have executed if it wasn't deleted,
+			// and check that the device record wasn't created.
+			await setTimeout(futureMS * 2);
+			const { body: devices } = await pineTest
+				.get({
+					apiPrefix: 'example/',
+					resource: 'device',
+					options: {
+						$filter: {
+							name,
+						},
+					},
+				})
+				.expect(200);
+			expect(devices).to.deep.equal([]);
+
+			// Assert no task_run records exist for this task.
+			const { body: taskRuns } = await pineTest.get({
+				resource: 'task_run',
+				options: {
+					$select: ['id'],
+					$filter: {
+						is_for__task: task.id,
+					},
+				},
+			});
+			expect(taskRuns.length).to.equal(0);
+		});
+
+		it('should retry on execution failures', async () => {
+			const { body: task } = await pineTest
+				.post({
+					resource: 'task',
+					body: {
+						is_for__model_name: 'example',
+						key: randomUUID(),
+						is_executed_by__handler: 'throw_error',
+						retry_limit: 1,
+						start_time: new Date(new Date().getTime() + getFutureMS()),
+						apikey,
+					},
+				})
+				.expect(201);
+
+			// Wait until when the task should have executed a couple of times.
+			// Assert the task retried a couple of times and ultimately failed.
+			await waitFor(async () => {
+				const { body: updatedTask } = await pineTest
+					.get({
+						resource: 'task',
+						id: task.id,
+						options: {
+							$select: [
+								'error_count',
+								'last_error',
+								'run_count',
+								'is_complete',
+							],
+						},
+					})
+					.expect(200);
+				return (
+					updatedTask.error_count === 1 &&
+					updatedTask.last_error !== null &&
+					updatedTask.run_count === 1 &&
+					updatedTask.is_complete === true
+				);
+			});
+
+			// Assert the expected task_run exists.
+			const { body: taskRuns } = await pineTest.get({
+				resource: 'task_run',
+				options: {
+					$select: ['end_time', 'error', 'start_time', 'status'],
+					$filter: {
+						is_for__task: task.id,
+					},
+				},
+			});
+			expect(taskRuns.length).to.equal(1);
+			expect(new Date(taskRuns[0].end_time).getTime()).to.be.greaterThan(
+				new Date(taskRuns[0].start_time).getTime(),
+			);
+			expect(taskRuns[0].error).to.equal('From throw_error task handler');
+			expect(taskRuns[0].status).to.equal('failed');
 		});
 	});
 });

--- a/test/fixtures/07-tasks/config.ts
+++ b/test/fixtures/07-tasks/config.ts
@@ -1,0 +1,28 @@
+import { ConfigLoader } from '../../../src/server-glue/module';
+
+export default {
+	models: [
+		{
+			modelName: 'Auth',
+			modelFile: __dirname + '/../../../src/sbvr-api/user.sbvr',
+			apiRoot: 'Auth',
+		},
+		{
+			modelName: 'tasks',
+			modelFile: __dirname + '/../../../src/sbvr-api/tasks.sbvr',
+			apiRoot: 'tasks',
+		},
+		{
+			modelName: 'example',
+			modelFile: __dirname + '/example.sbvr',
+			apiRoot: 'example',
+		},
+	],
+	users: [
+		{
+			username: 'guest',
+			password: ' ',
+			permissions: ['resource.all'],
+		},
+	],
+} as ConfigLoader.Config;

--- a/test/fixtures/07-tasks/example.sbvr
+++ b/test/fixtures/07-tasks/example.sbvr
@@ -1,0 +1,21 @@
+Vocabulary: example
+
+Term: name
+	  Concept Type: Short Text (Type)
+
+Term: note
+	  Concept Type: Text (Type)
+
+Term: type
+	  Concept Type: Short Text (Type)
+
+Term: device
+
+Fact Type: device has name
+	 Necessity: each device has at most one name.
+
+Fact Type: device has note
+	 Necessity: each device has at most one note.
+
+Fact Type: device has type
+	 Necessity: each device has exactly one type.

--- a/test/fixtures/07-tasks/task-handlers.ts
+++ b/test/fixtures/07-tasks/task-handlers.ts
@@ -1,0 +1,23 @@
+import { sbvrUtils } from '../../../src/server-glue/module';
+
+const client = new sbvrUtils.PinejsClient({
+	apiPrefix: '/example/',
+}) as sbvrUtils.LoggingClient;
+
+// Task handler that creates a record using the args.
+sbvrUtils.addTaskHandler(
+	'foobar',
+	{
+		name: 'string',
+		type: 'string',
+	},
+	async (args: { name: string; type: string }) => {
+		await client.post({
+			resource: 'device',
+			body: {
+				name: args.name,
+				type: args.type,
+			},
+		});
+	},
+);

--- a/test/fixtures/07-tasks/task-handlers.ts
+++ b/test/fixtures/07-tasks/task-handlers.ts
@@ -1,19 +1,23 @@
 import { sbvrUtils } from '../../../src/server-glue/module';
+import type * as Db from '../../../src/database-layer/db';
 
 const client = new sbvrUtils.PinejsClient({
 	apiPrefix: '/example/',
 }) as sbvrUtils.LoggingClient;
 
-// Task handler that creates a record using the args.
+// Task handler that creates a device using provided args.
 sbvrUtils.addTaskHandler(
-	'foobar',
+	'create_device',
 	{
 		name: 'string',
 		type: 'string',
 	},
-	async (args: { name: string; type: string }) => {
+	async (args: { name: string; type: string; tx: Db.Tx }) => {
 		await client.post({
 			resource: 'device',
+			passthrough: {
+				tx: args.tx,
+			},
 			body: {
 				name: args.name,
 				type: args.type,
@@ -21,3 +25,9 @@ sbvrUtils.addTaskHandler(
 		});
 	},
 );
+
+// Task handler that just throws an error.
+// Used for testing error handling and retries.
+sbvrUtils.addTaskHandler('throw_error', {}, () => {
+	throw new Error('From throw_error task handler');
+});

--- a/test/lib/pine-in-process.ts
+++ b/test/lib/pine-in-process.ts
@@ -19,6 +19,11 @@ export async function forkInit() {
 			await import(processArgs.hooksPath);
 		}
 
+		// load task handlers
+		if (processArgs.taskHandlersPath) {
+			await import(processArgs.taskHandlersPath);
+		}
+
 		if (processArgs.routesPath) {
 			const { initRoutes } = await import(processArgs.routesPath);
 			initRoutes(app);

--- a/test/lib/pine-init.ts
+++ b/test/lib/pine-init.ts
@@ -5,6 +5,7 @@ import * as pine from '../../src/server-glue/module';
 export type PineTestOptions = {
 	configPath: string;
 	hooksPath?: string;
+	taskHandlersPath?: string;
 	routesPath?: string;
 	deleteDb: boolean;
 	listenPort: number;

--- a/test/lib/test-init.ts
+++ b/test/lib/test-init.ts
@@ -14,6 +14,7 @@ export async function testInit(
 			deleteDb: options.deleteDb ?? boolVar('DELETE_DB', false),
 			configPath: options.configPath,
 			hooksPath: options.hooksPath,
+			taskHandlersPath: options.taskHandlersPath,
 			routesPath: options.routesPath,
 		};
 		const testServer = fork(


### PR DESCRIPTION
Change-type: minor

---

**[WIP]** Add a new `tasks` vocabulary with `job` as its primary resource. Consumers can first register new job handlers with `addTaskHandler()` (similar to `addPureHook()`), and then schedule tasks for future execution by creating `task` resources normally. Task executions are cancelled upon their resource counterpart being deleted. Limited retry/backoff logic included on execution failure. During startup, any pending jobs are either executed immediately or scheduled for future execution depending on their `start_time` date.

**Note:** Originally started with https://github.com/balena-io/pinejs/pull/654 which uses some existing migration functionality behind the scenes, but decided to try something that was completely decoupled from migrations. I'm looking for something to schedule and execute tasks, not migrations. While we could force the use of migrations, I'm not convinced it's the right decision - don't need async migrations/etc and wouldn't want to pollute migration tables with non-migration task records.

---

ToDo/Issues:
- Scope task handlers to models?
- Allow for retry/backoff value overrides
- Needs queueing of some sort? Worried about what happens when too many tasks are scheduled to execute at the same time.

---

Example usage can be found in `test/07-tasks.test.ts` and `test/fixtures/07-tasks/task-handlers.ts`.