### PR TITLE
Support returning a number from async migrations rather than db result

### DIFF
--- a/src/migrator/utils.ts
+++ b/src/migrator/utils.ts
@@ -29,7 +29,14 @@ export type MigrationFn = (tx: Tx, sbvrUtils: SbvrUtils) => Resolvable<void>;
 export type RunnableMigrations = { [key: string]: Migration };
 export type RunnableAsyncMigrations = { [key: string]: AsyncMigration };
 export type Migrations = CategorizedMigrations | RunnableMigrations;
-export type AsyncMigrationFn = (
+export type AsyncMigrationFn =
+	| ((tx: Tx, options: { batchSize: number }, sbvrUtils: SbvrUtils) => number)
+	| DeprecatedAsyncMigrationFn;
+
+/**
+ * @deprecated
+ */
+type DeprecatedAsyncMigrationFn = (
 	tx: Tx,
 	options: { batchSize: number },
 	sbvrUtils: SbvrUtils,


### PR DESCRIPTION
This also deprecates the form of returning a db result

Change-type: minor