### PR TITLE
Fix skipped migrations on empty database schema

### DIFF
--- a/src/migrator/sync.ts
+++ b/src/migrator/sync.ts
@@ -1,6 +1,7 @@
 import {
 	MigrationTuple,
 	MigrationError,
+	MigrationExecutionResult,
 	setExecutedMigrations,
 	getExecutedMigrations,
 	lockMigrations,
@@ -45,7 +46,10 @@ export const postRun = async (tx: Tx, model: ApiRootModel): Promise<void> => {
 	}
 };
 
-export const run = async (tx: Tx, model: ApiRootModel): Promise<void> => {
+export const run = async (
+	tx: Tx,
+	model: ApiRootModel,
+): Promise<MigrationExecutionResult> => {
 	const { migrations } = model;
 	if (migrations == null || _.isEmpty(migrations)) {
 		return;
@@ -58,7 +62,7 @@ const $run = async (
 	tx: Tx,
 	model: ApiRootModel,
 	migrations: RunnableMigrations,
-): Promise<void> => {
+): Promise<MigrationExecutionResult> => {
 	const modelName = model.apiRoot;
 
 	// migrations only run if the model has been executed before,
@@ -68,7 +72,6 @@ const $run = async (
 		(sbvrUtils.api.migrations?.logger.info ?? console.info)(
 			`First time model '${modelName}' has executed, skipping migrations`,
 		);
-
 		return await setExecutedMigrations(tx, modelName, Object.keys(migrations));
 	}
 	await lockMigrations({ tx, modelName, blocking: true }, async () => {

--- a/src/migrator/utils.ts
+++ b/src/migrator/utils.ts
@@ -105,6 +105,12 @@ export type MigrationStatus = {
 	is_backing_off: boolean;
 };
 
+export type MigrationExecutionResult =
+	| undefined
+	| {
+			pendingUnsetMigrations: string[];
+	  };
+
 export const getRunnableAsyncMigrations = (
 	$migrations: Migrations,
 ): RunnableAsyncMigrations | undefined => {
@@ -270,9 +276,9 @@ export const setExecutedMigrations = async (
 	tx: Tx,
 	modelName: string,
 	executedMigrations: string[],
-): Promise<void> => {
+): Promise<MigrationExecutionResult> => {
 	if (!(await migrationTablesExist(tx))) {
-		return;
+		return { pendingUnsetMigrations: executedMigrations };
 	}
 
 	const stringifiedMigrations = await sbvrUtils.sbvrTypes.JSON.validate(

--- a/src/server-glue/module.ts
+++ b/src/server-glue/module.ts
@@ -78,6 +78,9 @@ export const init = async <T extends string>(
 			promises.push(cfgLoader.loadApplicationConfig(config));
 		}
 		await Promise.all(promises);
+		// Execute it after all other promises have resolved. Execution of promises is not neccessarily
+		// guaranteed to be sequentially resolving them with Promise.all
+		await sbvrUtils.postSetup(app, db);
 
 		return cfgLoader;
 	} catch (err: any) {

--- a/test/03-async-migrator.test.ts
+++ b/test/03-async-migrator.test.ts
@@ -272,7 +272,7 @@ describe('03 Async Migrations', async function () {
 			// should only mark async migrations as executed when they are finalized.
 			// 0002 is not finalized, thus should not be marked as executed.
 			const res = await supertest(testLocalServer)
-				.get('/migrations/migration')
+				.get(`/migrations/migration?$filter=model_name eq 'example'`)
 				.expect(200);
 			expect(res.body)
 				.to.be.an('object')


### PR DESCRIPTION
On empty database schemas the `migrations` model is not executed. Hence, every model migration that is executed before the `migrations` model will not be tracked properly. This is an edge case for empty database schemas.

Change-type: patch