### PR TITLE
Fix $expand on parent resource with child webresource

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ An application can choose between two types to save file content or another larg
 
 Please note that `WebResource` is still a work in progress and as such has a few limitations. Such as (but not exclusively):
 
- - When expanding a resource on a webresource, the output content will not be pre-signed (needs to directly get the resource or association table)
  - Filtering for specific filenames or size
  - Deletion of a file may fail and will require to manually delete the file from its storage
 

--- a/src/config-loader/config-loader.ts
+++ b/src/config-loader/config-loader.ts
@@ -32,6 +32,7 @@ import {
 	getUploaderMiddlware,
 	WebResourceHandler,
 	setupUploadHooks,
+	setupWebresourceHandler,
 } from '../webresource-handler';
 import { AliasValidNodeType } from '../sbvr-api/translations';
 
@@ -205,6 +206,7 @@ export const setup = (app: Express.Application) => {
 						const webResourceHandler =
 							data.webResourceHandler ?? getDefaultHandler();
 
+						setupWebresourceHandler(webResourceHandler);
 						const fileUploadMiddleware =
 							getUploaderMiddlware(webResourceHandler);
 						app

--- a/src/webresource-handler/handlers/S3Handler.ts
+++ b/src/webresource-handler/handlers/S3Handler.ts
@@ -116,8 +116,10 @@ export class S3Handler implements WebResourceHandler {
 	}
 
 	public async onPreRespond(webResource: WebResource): Promise<WebResource> {
-		const fileKey = this.getKeyFromHref(webResource.href);
-		webResource.href = await this.cachedGetSignedUrl(fileKey);
+		if (webResource.href != null) {
+			const fileKey = this.getKeyFromHref(webResource.href);
+			webResource.href = await this.cachedGetSignedUrl(fileKey);
+		}
 		return webResource;
 	}
 


### PR DESCRIPTION
Change-type: patch

Context: When serving webresources we may need aditional postprocessing (e.g. signing the URL). This was previously done with a PRERESPONSE hook on the model that had a webresource. 

The problem with this approach is that one model that does not contain a webresource can be $expand on a field that contains a webresource and then the GET hook won't be setup and postprocessing (presigning) won't occur.

This PR solves the issue by presigning a level deeper into the stack. When we fetch a resource from the DB that is a webresource, we postprocess as a webresource will never be served without the postprocessing.