### PR TITLE
Handling typing changes of @types/pg

### DIFF
--- a/src/database-layer/db.ts
+++ b/src/database-layer/db.ts
@@ -546,12 +546,12 @@ if (maybePg != null) {
 			rowCount,
 			rows,
 		}: {
-			rowCount: number;
+			rowCount: number | null;
 			rows: Row[];
 		}): Result => {
 			return {
 				rows,
-				rowsAffected: rowCount,
+				rowsAffected: rowCount ?? 0,
 				insertId: rows?.[0]?.id,
 			};
 		};


### PR DESCRIPTION
rowCount can be NULL in the case of PG returning from `LOCK`

Refernece:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66990 https://github.com/brianc/node-postgres/pull/2967

In pinejs the case is handled and as of now we don't want to populate a breaking change by transparently push the types to callers.

Change-type: patch