### PR TITLE
Tests: Remove restart=always policy for sidecar containers

### DIFF
--- a/docker-compose.npm-test.yml
+++ b/docker-compose.npm-test.yml
@@ -2,7 +2,6 @@ version: "2.1"
 services:
   postgres:
     image: postgres:16-alpine
-    restart: always
     environment:
       POSTGRES_USER: docker
       POSTGRES_PASSWORD: docker
@@ -11,7 +10,6 @@ services:
       - "5431:5432"
   minio-server:
     image: minio/minio
-    restart: always
     environment:
       MINIO_ROOT_USER: USERNAME
       MINIO_ROOT_PASSWORD: PASSWORD


### PR DESCRIPTION
These will automatically be started by subsequent test commands as necessary and this will avoid them being unnecessarily started even after a reboot or similar when they are not necessary

Change-type: patch