### PR TITLE
odata/abstract-sql-compiler: Add support for specifying the model name for config files

### DIFF
--- a/src/bin/abstract-sql-compiler.ts
+++ b/src/bin/abstract-sql-compiler.ts
@@ -9,7 +9,10 @@ import { program } from 'commander';
 
 const runCompile = async (inputFile: string, outputFile?: string) => {
 	const { generateSqlModel } = await import('../sbvr-api/sbvr-utils.js');
-	const abstractSql = getAbstractSqlModelFromFile(inputFile);
+	const abstractSql = getAbstractSqlModelFromFile(
+		inputFile,
+		program.opts().model,
+	);
 	const sqlModel = generateSqlModel(abstractSql, program.opts().engine);
 
 	writeSqlModel(sqlModel, outputFile);
@@ -19,7 +22,10 @@ const generateTypes = async (inputFile: string, outputFile?: string) => {
 	const { abstractSqlToTypescriptTypes } = await import(
 		'@balena/abstract-sql-to-typescript/generate'
 	);
-	const abstractSql = getAbstractSqlModelFromFile(inputFile);
+	const abstractSql = getAbstractSqlModelFromFile(
+		inputFile,
+		program.opts().model,
+	);
 	const types = abstractSqlToTypescriptTypes(abstractSql);
 
 	writeAll(types, outputFile);
@@ -32,6 +38,10 @@ program
 		'The target database engine (postgres|websql|mysql), default: postgres',
 		/postgres|websql|mysql/,
 		'postgres',
+	)
+	.option(
+		'-m, --model <model-name>',
+		'The target model for config files with multiple models, default: first model',
 	);
 
 program

--- a/src/bin/utils.ts
+++ b/src/bin/utils.ts
@@ -48,8 +48,31 @@ ${rule.sql}`,
 	writeAll(output, outputFile);
 };
 
+const getConfigModel = (
+	fileContents: Model | AbstractSqlModel | Config,
+	modelName?: string,
+): Model | AbstractSqlModel => {
+	if ('models' in fileContents) {
+		if (fileContents.models.length === 0) {
+			throw new Error('No models found in config file');
+		}
+		if (modelName != null) {
+			const model = fileContents.models.find((m) => m.modelName === modelName);
+			if (model == null) {
+				throw new Error(
+					`Could not find model with name '${modelName}', found: ${fileContents.models.map((m) => m.modelName).join(', ')}`,
+				);
+			}
+			return model;
+		}
+		return fileContents.models[0];
+	}
+	return fileContents;
+};
+
 export const getAbstractSqlModelFromFile = (
 	modelFile: string,
+	modelName: string | undefined,
 ): AbstractSqlModel => {
 	let fileContents: string | Model | AbstractSqlModel | Config;
 	try {
@@ -67,8 +90,7 @@ export const getAbstractSqlModelFromFile = (
 		if ('tables' in fileContents) {
 			return fileContents;
 		}
-		const configModel =
-			'models' in fileContents ? fileContents.models[0] : fileContents;
+		const configModel = getConfigModel(fileContents, modelName);
 		if ('abstractSql' in configModel && configModel.abstractSql != null) {
 			return configModel.abstractSql as AbstractSqlModel;
 		} else if ('modelText' in configModel && configModel.modelText != null) {

--- a/test/fixtures/04-translations/config.ts
+++ b/test/fixtures/04-translations/config.ts
@@ -10,7 +10,7 @@ import { v1AbstractSqlModel, v1Translations } from './translations/v1';
 import { v2AbstractSqlModel, v2Translations } from './translations/v2';
 import { v3AbstractSqlModel, v3Translations } from './translations/v3';
 
-export const abstractSql = getAbstractSqlModelFromFile(modelFile);
+export const abstractSql = getAbstractSqlModelFromFile(modelFile, undefined);
 
 abstractSql.tables['student'].fields.push({
 	fieldName: 'computed field',

--- a/test/fixtures/04-translations/translations/v1/index.ts
+++ b/test/fixtures/04-translations/translations/v1/index.ts
@@ -6,6 +6,7 @@ export const toVersion = 'v2';
 
 export const v1AbstractSqlModel = getAbstractSqlModelFromFile(
 	__dirname + '/university.sbvr',
+	undefined,
 );
 
 v1AbstractSqlModel.tables['student'].fields.push({

--- a/test/fixtures/04-translations/translations/v2/index.ts
+++ b/test/fixtures/04-translations/translations/v2/index.ts
@@ -7,6 +7,7 @@ import type {
 
 export const v2AbstractSqlModel = getAbstractSqlModelFromFile(
 	__dirname + '/university.sbvr',
+	undefined,
 );
 
 export const toVersion = 'v3';

--- a/test/fixtures/04-translations/translations/v3/index.ts
+++ b/test/fixtures/04-translations/translations/v3/index.ts
@@ -4,6 +4,7 @@ import type { AbstractSqlQuery } from '@balena/abstract-sql-compiler';
 
 export const v3AbstractSqlModel = getAbstractSqlModelFromFile(
 	__dirname + '/university.sbvr',
+	undefined,
 );
 
 export const toVersion = 'university';

--- a/test/fixtures/06-webresource/translations/v1/index.ts
+++ b/test/fixtures/06-webresource/translations/v1/index.ts
@@ -5,6 +5,7 @@ export const toVersion = 'example';
 
 export const v1AbstractSqlModel = getAbstractSqlModelFromFile(
 	__dirname + '/example.sbvr',
+	undefined,
 );
 
 v1AbstractSqlModel.relationships['version'] = { v1: {} };


### PR DESCRIPTION
This allows choosing which model to use when the config file contains multiple models

Change-type: minor