### PR TITLE
Fix getIdField using idField of intermediate translation

### DIFF
--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -1166,9 +1166,13 @@ const getIdField = (
 		| 'resourceName'
 		| 'vocabulary'
 	>,
-) =>
-	// TODO: Should resolveSynonym also be using the finalAbstractSqlModel?
-	getFinalAbstractSqlModel(request).tables[resolveSynonym(request)].idField;
+) => {
+	const resolvedSynonym = resolveSynonym(request);
+	const translatedTable = getAbstractSqlModel(request).tables[resolvedSynonym];
+	const resourceName =
+		translatedTable != null ? translatedTable.resourceName : resolvedSynonym;
+	return getFinalAbstractSqlModel(request).tables[resourceName].idField;
+};
 
 export const getAffectedIds = async <Vocab extends string>(
 	args: HookArgs<Vocab> & {

--- a/test/fixtures/04-translations/config.ts
+++ b/test/fixtures/04-translations/config.ts
@@ -9,6 +9,8 @@ const modelFile = __dirname + '/university.sbvr';
 import { v1AbstractSqlModel, v1Translations } from './translations/v1';
 import { v2AbstractSqlModel, v2Translations } from './translations/v2';
 import { v3AbstractSqlModel, v3Translations } from './translations/v3';
+import { v4AbstractSqlModel } from './translations/v4';
+import { v5AbstractSqlModel } from './translations/v5';
 
 export const abstractSql = getAbstractSqlModelFromFile(modelFile, undefined);
 
@@ -27,10 +29,24 @@ export default {
 			apiRoot,
 		},
 		{
+			apiRoot: 'v5',
+			modelName: 'v5',
+			abstractSql: v5AbstractSqlModel,
+			translateTo: 'university',
+			translations: {},
+		},
+		{
+			apiRoot: 'v4',
+			modelName: 'v4',
+			abstractSql: v4AbstractSqlModel,
+			translateTo: 'v5',
+			translations: {},
+		},
+		{
 			apiRoot: 'v3',
 			modelName: 'v3',
 			abstractSql: v3AbstractSqlModel,
-			translateTo: 'university',
+			translateTo: 'v4',
 			translations: v3Translations,
 		},
 		{

--- a/test/fixtures/04-translations/translations/v3/index.ts
+++ b/test/fixtures/04-translations/translations/v3/index.ts
@@ -7,7 +7,7 @@ export const v3AbstractSqlModel = getAbstractSqlModelFromFile(
 	undefined,
 );
 
-export const toVersion = 'university';
+export const toVersion = 'v4';
 
 v3AbstractSqlModel.tables['student'].fields.push({
 	fieldName: 'computed field',

--- a/test/fixtures/04-translations/translations/v4/index.ts
+++ b/test/fixtures/04-translations/translations/v4/index.ts
@@ -1,0 +1,18 @@
+import { getAbstractSqlModelFromFile } from '../../../../../src/bin/utils';
+import type { AbstractSqlQuery } from '@balena/abstract-sql-compiler';
+
+export const v4AbstractSqlModel = getAbstractSqlModelFromFile(
+	__dirname + '/university.sbvr',
+	undefined,
+);
+
+export const toVersion = 'v5';
+
+v4AbstractSqlModel.tables['student'].fields.push({
+	fieldName: 'computed field',
+	dataType: 'Text',
+	required: false,
+	computed: ['EmbeddedText', 'v4_computed_field'] as AbstractSqlQuery,
+});
+
+v4AbstractSqlModel.relationships['version'] = { v4: {} };

--- a/test/fixtures/04-translations/translations/v4/university.sbvr
+++ b/test/fixtures/04-translations/translations/v4/university.sbvr
@@ -1,0 +1,31 @@
+Vocabulary: university
+
+Term: name
+	Concept Type: Short Text (Type)
+
+Term: last name
+	Concept Type: Short Text (Type)
+
+Term: matrix number
+	Concept Type: Integer (Type)
+
+Term: faculty
+
+Fact Type: faculty has name
+	Necessity: each faculty has exactly one name
+	Necessity: each name is of exactly one faculty
+
+Term: student
+
+Fact Type: student has matrix number
+	Necessity: each student has exactly one matrix number
+	Necessity: each matrix number is of exactly one student
+
+Fact Type: student has name
+	Necessity: each student has exactly one name
+
+Fact Type: student has last name
+	Necessity: each student has exactly one last name
+
+Fact Type: student studies at faculty
+	Necessity: each student studies at exactly one faculty

--- a/test/fixtures/04-translations/translations/v5/index.ts
+++ b/test/fixtures/04-translations/translations/v5/index.ts
@@ -1,0 +1,18 @@
+import { getAbstractSqlModelFromFile } from '../../../../../src/bin/utils';
+import type { AbstractSqlQuery } from '@balena/abstract-sql-compiler';
+
+export const v5AbstractSqlModel = getAbstractSqlModelFromFile(
+	__dirname + '/university.sbvr',
+	undefined,
+);
+
+export const toVersion = 'university';
+
+v5AbstractSqlModel.tables['student'].fields.push({
+	fieldName: 'computed field',
+	dataType: 'Text',
+	required: false,
+	computed: ['EmbeddedText', 'v5_computed_field'] as AbstractSqlQuery,
+});
+
+v5AbstractSqlModel.relationships['version'] = { v5: {} };

--- a/test/fixtures/04-translations/translations/v5/university.sbvr
+++ b/test/fixtures/04-translations/translations/v5/university.sbvr
@@ -1,0 +1,31 @@
+Vocabulary: university
+
+Term: name
+	Concept Type: Short Text (Type)
+
+Term: last name
+	Concept Type: Short Text (Type)
+
+Term: matrix number
+	Concept Type: Integer (Type)
+
+Term: faculty
+
+Fact Type: faculty has name
+	Necessity: each faculty has exactly one name
+	Necessity: each name is of exactly one faculty
+
+Term: student
+
+Fact Type: student has matrix number
+	Necessity: each student has exactly one matrix number
+	Necessity: each matrix number is of exactly one student
+
+Fact Type: student has name
+	Necessity: each student has exactly one name
+
+Fact Type: student has last name
+	Necessity: each student has exactly one last name
+
+Fact Type: student studies at faculty
+	Necessity: each student studies at exactly one faculty


### PR DESCRIPTION
getIdField tries to return the name of the id field in the database model (and not in any translated model)
This turns out to be a problem when more than one layer of native translations are present for a given table as it tries to use the resource name of a given version on the final abstract sql model

This approach will use the actual translation (rather than the final one) in case the translated table exists, avoiding trying to find a non existent translation on the final model

Resolves: https://github.com/balena-io/pinejs/issues/794
Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/345890-balena-io/topic/pinejs.20bump.20dependencies/near/455374721