### PR TITLE
Convert unknown errors to 500 errors rather than 404 for clarity

### DIFF
--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -55,7 +55,6 @@ import {
 	HttpError,
 	InternalRequestError,
 	MethodNotAllowedError,
-	NotFoundError,
 	ParsingError,
 	PermissionError,
 	PermissionParsingError,
@@ -1567,7 +1566,7 @@ const convertToHttpError = (err: any): HttpError => {
 	}
 
 	console.error('Unexpected response error type', err);
-	return new NotFoundError(err);
+	return new InternalRequestError();
 };
 
 const runRequest = async (


### PR DESCRIPTION
500 internal request error is far more accurate to the reality than a 404 not found, and removing the error message also adds safety to these unexpected errors

Change-type: patch