### PR TITLE
Update sbvr-types to v9.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@balena/odata-parser": "^3.0.8",
     "@balena/odata-to-abstract-sql": "^6.2.7",
     "@balena/sbvr-parser": "^1.4.6",
-    "@balena/sbvr-types": "^7.1.3",
+    "@balena/sbvr-types": "^9.0.1",
     "@types/body-parser": "^1.19.5",
     "@types/compression": "^1.7.5",
     "@types/cookie-parser": "^1.4.7",


### PR DESCRIPTION
Change-type: major

---

Updating as a major as this version of sbvr-types includes breaking changes for BigInt and BigSerial that we pass down to our consumers.