### PR TITLE
Allow changing pine's DEBUG mode on runtime when env.DEPLOYMENT=TEST

### DIFF
--- a/src/config-loader/env.ts
+++ b/src/config-loader/env.ts
@@ -2,7 +2,7 @@ const { PINEJS_DEBUG } = process.env;
 if (![undefined, '', '0', '1'].includes(PINEJS_DEBUG)) {
 	throw new Error(`Invalid value for PINEJS_DEBUG '${PINEJS_DEBUG}'`);
 }
-export const DEBUG = PINEJS_DEBUG === '1';
+export let DEBUG = PINEJS_DEBUG === '1';
 
 type CacheFnOpts<T extends (...args: any[]) => any> =
 	| {
@@ -150,4 +150,16 @@ export const migrator = {
 export const tasks = {
 	queueConcurrency: intVar('PINEJS_QUEUE_CONCURRENCY', 0),
 	queueIntervalMS: intVar('PINEJS_QUEUE_INTERVAL_MS', 1000),
+};
+
+export const guardTestMockOnly = () => {
+	if (process.env.DEPLOYMENT !== 'TEST') {
+		throw new Error('Attempting to use TEST_MOCK_ONLY outside of tests');
+	}
+};
+export const TEST_MOCK_ONLY = {
+	set DEBUG(v: typeof DEBUG) {
+		guardTestMockOnly();
+		DEBUG = v;
+	},
 };


### PR DESCRIPTION
This allows consumers to enable debug mode
only for a single test case, reducing the
amount of noise in their logs.

This allows consumers to for example print the SQL run during a specific test case, by doing
```ts
it('tests something', function () {
	const { env: { TEST_MOCK_ONLY } } = await import('@balena/pinejs');
	TEST_MOCK_ONLY.DEBUG = true;
	// ... tests here
	TEST_MOCK_ONLY.DEBUG = false;
});
```

Change-type: minor