### PR TITLE
Expose `checkApiKey` to allow resolving an api key string

### DIFF
--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -1536,7 +1536,7 @@ const getApiKeyActorId = (() => {
 	);
 })();
 
-const checkApiKey = async (
+export const checkApiKey = async (
 	apiKey: string,
 	tx?: Tx,
 ): Promise<PermissionReq['apiKey']> => {


### PR DESCRIPTION
This allows for custom api key handlers that don't rely on `resolveAuthHeader` or `resolveApiKey`

Change-type: minor