### PR TITLE
Optimistically search for resource on translatesTo table

### DIFF
--- a/src/sbvr-api/translations.ts
+++ b/src/sbvr-api/translations.ts
@@ -250,7 +250,9 @@ export const translateAbstractSqlModel = (
 					fromAbstractSqlModel,
 					toAbstractSqlModel,
 					key,
-					aliasedToResource,
+					toAbstractSqlModel.tables[aliasedToResource] != null
+						? aliasedToResource
+						: unaliasedToResource,
 					definition,
 				);
 			}


### PR DESCRIPTION
When translating an abstractSqlModel the passed translated model might not have been compiled yet and not have the associated resource$alias keys. In this case, we can optimistically search for unaliased resouces that match exactly the one $toResource is translating to

Change-type: patch