### PR TITLE
Fix missing required validation on bindings

### DIFF
--- a/test/01-constrain.test.ts
+++ b/test/01-constrain.test.ts
@@ -73,5 +73,14 @@ describe('01 basic constrain tests', function () {
 					'It is necessary that each student that has a semester credits, has a semester credits that is greater than or equal to 4 and is less than or equal to 16.',
 				);
 		});
+
+		it('should error on invalid parameter type', async () => {
+			await supertest(testLocalServer)
+				.patch('/university/student(1)')
+				.send({
+					name: null,
+				})
+				.expect(400, '"\\"name\\" cannot be null"');
+		});
 	});
 });


### PR DESCRIPTION
In previous commit `bdb34d` the code path for `getAndCheckBindValues` was simplified considering the declared type of `{dataType: string}`. That typing is not complete and thus the simplification was wrong.

The field property may also contain a `required` property which is used for doing oData validation (from sbvr-types) In that simplification we excluded the required information for bound variables: https://github.com/balena-io/pinejs/commit/bdb34d9df39e0d9d00db492cbb1ef6dfc61e8450#diff-abade937407ef92d95cd36b5719e481229475da7d3f8bdc613bebef8971c35d2R107

This reverts back the code simplification but keeping the necessary changes for List binding type.

Change-type: patch