### PR TITLE
fix: Resolve `\canAccess` for term forms

### DIFF
--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -1374,13 +1374,18 @@ const runODataRequest = (req: Express.Request, vocabulary: string) => {
 				>;
 				// Add/check the relevant permissions
 				try {
-					let resolvedResourceName = resolveSynonym($request);
-					if (resolvedResourceName.endsWith('#canAccess')) {
-						resolvedResourceName = resolvedResourceName.slice(
-							0,
-							-'#canAccess'.length,
-						);
-					}
+					const resolvedResourceName = $request.resourceName.endsWith(
+						'#canAccess',
+					)
+						? resolveSynonym({
+								...$request,
+								resourceName: $request.resourceName.slice(
+									0,
+									-'#canAccess'.length,
+								),
+							})
+						: resolveSynonym($request);
+
 					if (abstractSqlModel.tables[resolvedResourceName] == null) {
 						throw new UnauthorizedError();
 					}

--- a/test/07-permissions.test.ts
+++ b/test/07-permissions.test.ts
@@ -67,6 +67,41 @@ describe('07 permissions tests', function () {
 				})
 				.expect(200);
 		});
+
+		it('should be able to create a badge for a student', async () => {
+			const { body } = await supertest(testLocalServer)
+				.post('/university/student_badge')
+				.set('Cookie', adminCookie)
+				.send({
+					student: 1,
+					badge_key: 'role',
+					badge_value: 'admin',
+				})
+				.expect(201);
+			expect(body.id).to.be.eq(1);
+			expect(body.badge_key).to.be.eq('role');
+			expect(body.badge_value).to.be.eq('admin');
+		});
+
+		it('should be able to check access for student__has__badge_key', async () => {
+			await supertest(testLocalServer)
+				.post('/university/student__has__badge_key(1)/canAccess')
+				.set('Cookie', adminCookie)
+				.send({
+					method: 'GET',
+				})
+				.expect(200);
+		});
+
+		it('should be able to check access for student_badge (term form)', async () => {
+			await supertest(testLocalServer)
+				.post('/university/student_badge(1)/canAccess')
+				.set('Cookie', adminCookie)
+				.send({
+					method: 'GET',
+				})
+				.expect(200);
+		});
 	});
 
 	describe('university vocabulary with guest permissions', () => {

--- a/test/fixtures/07-permissions/university.sbvr
+++ b/test/fixtures/07-permissions/university.sbvr
@@ -15,6 +15,11 @@ Term: semester credits
 Term: matrix number
 	Concept Type: Integer (Type)
 
+Term: badge key
+	Concept Type: Short Text (Type)
+
+Term: badge value
+	Concept Type: Short Text (Type)
 
 Term: student
 
@@ -34,3 +39,10 @@ Fact Type: student has birthday
 Fact Type: student has semester credits
 	Necessity: each student has at most one semester credits
 	Necessity: each student that has a semester credits, has a semester credits that is greater than or equal to 4 and is less than or equal to 16.
+
+Fact Type: student has badge key
+	Term Form: student badge
+	Database Table Name: student badge
+
+Fact type: student badge has badge value
+	Necessity: each student badge has exactly one badge value.


### PR DESCRIPTION
There is currently a bug which blocks using `/canAccess` on resources that have a term form.

It was found that this is due to the fact that [resolveSynonym](https://github.com/balena-io/pinejs/blob/40b26617fff9e9eefd2076d46445409a5ec331ae/src/sbvr-api/sbvr-utils.ts#L189) is not able to work with resourcenames that finish with `#canAccess` for properly resolving the synonym.

This approaches strips the `#canAccess` from the resource name before resolving translations. Another approach would be to extend `resolveSynonym` to always try to do it the function itself, however, this could have performance impact on other places calling this function and I like the implemented approach more as it keeps the code specific to canAccess in a single place.

See: https://balena.zulipchat.com/#narrow/channel/346007-balena-io.2FbalenaCloud/topic/.60.2FcanAccess.60.20weirdness

Change-type: patch