### PR TITLE
Tests: use faster config for postgres

### DIFF
--- a/docker-compose.npm-test.yml
+++ b/docker-compose.npm-test.yml
@@ -9,6 +9,13 @@ services:
       TZ: UTC
     ports:
       - "5431:5432"
+    command:
+      - -c
+      - synchronous_commit=off
+      - -c
+      - fsync=off
+      - -c
+      - full_page_writes=off
   minio-server:
     image: minio/minio:RELEASE.2024-09-22T00-33-43Z
     environment:


### PR DESCRIPTION
These settings are not safe for data we care about as we might lose or corrupt data in the case of power failure, but for test data where that is not an issue they offer a performance benefit

Change-type: patch