### PR TITLE
Update @balena/odata-to-abstract-sql to 7.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@balena/env-parsing": "^1.2.4",
     "@balena/lf-to-abstract-sql": "^5.0.3",
     "@balena/odata-parser": "^4.2.2",
-    "@balena/odata-to-abstract-sql": "^7.1.4",
+    "@balena/odata-to-abstract-sql": "^7.1.6",
     "@balena/sbvr-parser": "^1.4.9",
     "@balena/sbvr-types": "^9.2.2",
     "@types/body-parser": "^1.19.5",


### PR DESCRIPTION
Update @balena/odata-to-abstract-sql from 7.1.4 to 7.1.6

Depends-on: https://github.com/balena-io-modules/odata-to-abstract-sql/pull/160
Change-type: patch