### PR TITLE
Add multipart upload interface for handlers

### DIFF
--- a/src/webresource-handler/index.ts
+++ b/src/webresource-handler/index.ts
@@ -31,10 +31,51 @@ export interface UploadResponse {
 	filename: string;
 }
 
+export interface BeginMultipartUploadPayload {
+	filename: string;
+	content_type: string;
+	size: number;
+	chunk_size: number;
+}
+
+export interface UploadPart {
+	url: string;
+	chunkSize: number;
+	partNumber: number;
+}
+
+export interface BeginMultipartUploadHandlerResponse {
+	uploadParts: UploadPart[];
+	fileKey: string;
+	uploadId: string;
+}
+
+export interface CommitMultipartUploadPayload {
+	fileKey: string;
+	uploadId: string;
+	filename: string;
+	providerCommitData?: Record<string, any>;
+}
+
+export interface CancelMultipartUploadPayload {
+	fileKey: string;
+	uploadId: string;
+}
+
 export interface WebResourceHandler {
 	handleFile: (resource: IncomingFile) => Promise<UploadResponse>;
 	removeFile: (fileReference: string) => Promise<void>;
 	onPreRespond: (webResource: WebResource) => Promise<WebResource>;
+	multipartUpload?: {
+		begin: (
+			fieldName: string,
+			payload: BeginMultipartUploadPayload,
+		) => Promise<BeginMultipartUploadHandlerResponse>;
+		commit: (commitInfo: CommitMultipartUploadPayload) => Promise<WebResource>;
+		cancel: (cancelInfo: CancelMultipartUploadPayload) => Promise<void>;
+		getMinimumPartSize: () => number;
+		getDefaultPartSize: () => number;
+	};
 }
 
 export class WebResourceError extends TypedError {}


### PR DESCRIPTION
This PR only adds the optional multipart payload on the webresource handler. Handlers can (or not) implement this functionality and pinejs should be able to deal with both cases. Each handler has its own tests on its own repo, for a implementation reference see here: https://github.com/balena-io-modules/pinejs-webresource-s3/pull/8

See: https://balena.fibery.io/search/PtK6F#Work/Improvement/Add-multipart-upload-interface-for-webresource-handlers-and-add-them-to-S3-Cloudfront-handlers-2584
Change-type: minor