### PR TITLE
Translations: simplify the generated definition when only `$toResource` is provided

### DIFF
--- a/src/sbvr-api/translations.ts
+++ b/src/sbvr-api/translations.ts
@@ -238,6 +238,11 @@ export const translateAbstractSqlModel = (
 			table.modifyName = toTable.modifyName ?? toTable.name;
 			if (isDefinition(definition)) {
 				table.definition = definition;
+			} else if (Object.keys(definition).length === 0) {
+				// If there are no translation definitions, we can just target the `$toResource`
+				table.definition = {
+					abstractSql: ['Resource', aliasedToResource],
+				};
 			} else {
 				table.definition = aliasResource(
 					// fromAbstractSqlModel is the translation model as it contains


### PR DESCRIPTION
This avoids unnecessary indirection in the generated SQL for this case and so will reduce the size of the generated SQL and hence the memory usage by cache and network usage to transmit the queries

Change-type: patch