### PR TITLE
Permissions: simplify the constrained abstract sql by using `SELECT *`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@balena/env-parsing": "^1.2.5",
     "@balena/lf-to-abstract-sql": "^5.0.10",
     "@balena/odata-parser": "^4.2.6",
-    "@balena/odata-to-abstract-sql": "^10.0.0",
+    "@balena/odata-to-abstract-sql": "^10.0.2",
     "@balena/sbvr-parser": "^1.4.12",
     "@balena/sbvr-types": "^11.1.3",
     "@sindresorhus/fnv1a": "^3.1.0",

--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -2,13 +2,8 @@ import type AuthModel from './user.js';
 import { abstractSqlContainsNode } from '@balena/abstract-sql-compiler';
 import type {
 	AbstractSqlModel,
-	AbstractSqlQuery,
 	AbstractSqlTable,
-	AliasNode,
-	AnyTypeNodes,
 	Definition,
-	FieldNode,
-	ReferencedFieldNode,
 	Relationship,
 	RelationshipInternalNode,
 	RelationshipLeafNode,
@@ -30,7 +25,6 @@ import type { AnyObject, Dictionary } from './common-types.js';
 import {
 	isBindReference,
 	type OData2AbstractSQL,
-	odataNameToSqlName,
 	type ResourceFunction,
 	sqlNameToODataName,
 } from '@balena/odata-to-abstract-sql';
@@ -666,26 +660,7 @@ const generateConstrainedAbstractSql = (
 	const select = abstractSqlQuery.find(
 		(v): v is SelectNode => v[0] === 'Select',
 	)!;
-	select[1] = select[1].map((selectField): AnyTypeNodes => {
-		if (selectField[0] === 'Alias') {
-			const sqlName = odataNameToSqlName((selectField as AliasNode<any>)[2]);
-			const maybeField = (
-				selectField as AliasNode<
-					ReferencedFieldNode | FieldNode | AbstractSqlQuery
-				>
-			)[1];
-			if (
-				(maybeField[0] === 'ReferencedField' && maybeField[2] === sqlName) ||
-				(maybeField[0] === 'Field' && maybeField[1] === sqlName)
-			) {
-				// If the field name matches the sql name version of the alias then use it directly
-				return maybeField;
-			}
-			// Otherwise update the alias to use the sql name
-			return ['Alias', maybeField, sqlName];
-		}
-		return selectField;
-	});
+	select[1] = [['Field', '*']];
 
 	return { binds: odataBinds, abstractSql: abstractSqlQuery };
 };


### PR DESCRIPTION
This avoids the need to manually reference each field and shrinks the permissions SQL and makes the intent clearer/more understandable

Change-type: patch