### PR TITLE
Use zod schemas from sbvr-types to perform early validation before passing to hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@balena/odata-parser": "^4.3.0",
     "@balena/odata-to-abstract-sql": "^10.0.4",
     "@balena/sbvr-parser": "^1.4.13",
-    "@balena/sbvr-types": "^11.1.4",
+    "@balena/sbvr-types": "^11.3.0",
     "@sindresorhus/fnv1a": "^3.1.0",
     "@types/compression": "^1.8.1",
     "@types/cookie-parser": "^1.4.9",
@@ -67,7 +67,8 @@
     "memoizee": "^0.4.17",
     "pinejs-client-core": "^8.5.29",
     "randomstring": "^1.3.1",
-    "typed-error": "^3.2.2"
+    "typed-error": "^3.2.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@balena/lint": "^9.3.8",

--- a/src/pinejs-session-store/pinejs-session-store.ts
+++ b/src/pinejs-session-store/pinejs-session-store.ts
@@ -72,7 +72,8 @@ export class PinejsSessionStore extends Store {
 	public set = ((sid, data, callback) => {
 		const body = {
 			session_id: sid,
-			data,
+			// Convert from a `Session` instance into a plain object that is valid to pass
+			data: { ...data },
 			expiry_time: data?.cookie?.expires ?? null,
 		};
 		void asCallback(

--- a/src/sbvr-api/cached-compile.ts
+++ b/src/sbvr-api/cached-compile.ts
@@ -2,6 +2,7 @@ import type Fs from 'fs';
 
 import { optionalVar } from '@balena/env-parsing';
 import _ from 'lodash';
+import { stringifyIgnoreValidator } from './validation.js';
 
 const cacheFile = optionalVar('PINEJS_CACHE_FILE', '.pinejs-cache.json');
 let cache: null | {
@@ -22,11 +23,16 @@ const SAVE_DEBOUNCE_TIME = 5000;
 
 const saveCache = _.debounce(() => {
 	if (fs != null) {
-		fs.writeFile(cacheFile, JSON.stringify(cache), 'utf8', (err) => {
-			if (err) {
-				console.warn('Error saving pinejs cache:', err);
-			}
-		});
+		fs.writeFile(
+			cacheFile,
+			JSON.stringify(cache, stringifyIgnoreValidator),
+			'utf8',
+			(err) => {
+				if (err) {
+					console.warn('Error saving pinejs cache:', err);
+				}
+			},
+		);
 	}
 }, SAVE_DEBOUNCE_TIME);
 

--- a/src/sbvr-api/deep-freeze.ts
+++ b/src/sbvr-api/deep-freeze.ts
@@ -1,0 +1,37 @@
+import type { AnyObject } from './common-types.js';
+
+export const WILDCARD = Symbol('*');
+export const TERMINATE = Symbol('TERMINATE');
+/**
+ * Allow skipping properties whilst deep freezing in cases we know it's a property we've defined that will throw an error in some cases
+ */
+export const deepFreezeExceptPaths = (
+	obj: AnyObject,
+	excludePaths: Array<Array<string | typeof WILDCARD | typeof TERMINATE>> = [],
+) => {
+	if (!excludePaths.some((path) => path.length === 0)) {
+		Object.freeze(obj);
+	}
+
+	propLoop: for (const prop of Object.getOwnPropertyNames(obj)) {
+		const newExcludePaths: typeof excludePaths = [];
+		for (const path of excludePaths) {
+			if (path.length > 0 && (path[0] === prop || path[0] === WILDCARD)) {
+				if (path[1] === TERMINATE) {
+					// If we're terminating at this path/prop then we don't want to even try to access it as that could trigger getters or other side effects,
+					// so we continue the outer loop
+					continue propLoop;
+				}
+				newExcludePaths.push(path.slice(1));
+			}
+		}
+
+		if (
+			Object.hasOwn(obj, prop) &&
+			obj[prop] !== null &&
+			(typeof obj[prop] === 'object' || typeof obj[prop] === 'function')
+		) {
+			deepFreezeExceptPaths(obj[prop], newExcludePaths);
+		}
+	}
+};

--- a/src/sbvr-api/permissions.ts
+++ b/src/sbvr-api/permissions.ts
@@ -52,6 +52,7 @@ import type { Config } from '../config-loader/config-loader.js';
 import type { ODataOptions } from 'pinejs-client-core';
 import type { Permission } from './user.js';
 import { importSBVR } from '../server-glue/sbvr-loader.js';
+import { deepFreezeExceptPaths, TERMINATE, WILDCARD } from './deep-freeze.js';
 
 const userModel = await importSBVR('./user.sbvr', import.meta);
 
@@ -703,39 +704,6 @@ const onceGetter = <T, U extends keyof T>(
 	});
 };
 
-const WILDCARD = Symbol('*');
-const TERMINATE = Symbol('TERMINATE');
-const deepFreezeExceptPaths = (
-	obj: AnyObject,
-	excludePaths: Array<Array<string | typeof WILDCARD | typeof TERMINATE>> = [],
-) => {
-	if (!excludePaths.some((path) => path.length === 0)) {
-		Object.freeze(obj);
-	}
-
-	propLoop: for (const prop of Object.getOwnPropertyNames(obj)) {
-		const newExcludePaths: typeof excludePaths = [];
-		for (const path of excludePaths) {
-			if (path.length > 0 && (path[0] === prop || path[0] === WILDCARD)) {
-				if (path[1] === TERMINATE) {
-					// If we're terminating at this path/prop then we don't want to even try to access it as that could trigger getters or other side effects,
-					// so we continue the outer loop
-					continue propLoop;
-				}
-				newExcludePaths.push(path.slice(1));
-			}
-		}
-
-		if (
-			Object.hasOwn(obj, prop) &&
-			obj[prop] !== null &&
-			(typeof obj[prop] === 'object' || typeof obj[prop] === 'function')
-		) {
-			deepFreezeExceptPaths(obj[prop], newExcludePaths);
-		}
-	}
-};
-
 const createBypassDefinition = (definition: Definition) =>
 	_.cloneDeepWith(definition, (abstractSql) => {
 		if (
@@ -1232,6 +1200,7 @@ const getBoundConstrainedMemoizer = memoizeWeak(
 				deepFreezeExceptPaths(constrainedAbstractSqlModel, [
 					['tables'],
 					['tables', WILDCARD],
+					['tables', WILDCARD, 'validator', TERMINATE],
 					['tables', WILDCARD, 'definition', TERMINATE],
 					['synonyms'],
 					['relationships'],

--- a/src/sbvr-api/sbvr-utils.ts
+++ b/src/sbvr-api/sbvr-utils.ts
@@ -38,7 +38,6 @@ import {
 } from '@balena/odata-to-abstract-sql';
 import $sbvrTypes from '@balena/sbvr-types';
 const { default: sbvrTypes } = $sbvrTypes;
-import deepFreeze from 'deep-freeze';
 import type { ActionParams, ODataOptions, Params } from 'pinejs-client-core';
 import { PinejsClientCore, type PromiseResultTypes } from 'pinejs-client-core';
 
@@ -105,6 +104,7 @@ import {
 } from './abstract-sql.js';
 export { resolveOdataBind } from './abstract-sql.js';
 import * as odataResponse from './odata-response.js';
+import * as validation from './validation.js';
 import { env } from '../server-glue/module.js';
 import { translateAbstractSqlModel } from './translations.js';
 import {
@@ -112,6 +112,8 @@ import {
 	setExecutedMigrations,
 } from '../migrator/utils.js';
 import { isActionRequest, runAction } from './actions.js';
+import { stringifyIgnoreValidator } from './validation.js';
+import { deepFreezeExceptPaths, TERMINATE, WILDCARD } from './deep-freeze.js';
 
 const LF2AbstractSQLTranslator = LF2AbstractSQL.createTranslator(sbvrTypes);
 const LF2AbstractSQLTranslatorVersion = `${LF2AbstractSQLVersion}+${sbvrTypesVersion}`;
@@ -665,7 +667,10 @@ export const executeModels = async (
 				await syncMigrator.postRun(tx, model);
 
 				odataResponse.prepareModel(compiledModel.abstractSql);
-				deepFreeze(compiledModel.abstractSql);
+				validation.prepareModel(compiledModel.abstractSql);
+				deepFreezeExceptPaths(compiledModel.abstractSql, [
+					['tables', WILDCARD, 'validator', TERMINATE],
+				]);
 
 				const versions = [apiRoot];
 				if (compiledModel.translateTo != null) {
@@ -748,7 +753,10 @@ export const executeModels = async (
 						model_value:
 							typeof model[modelType] === 'string'
 								? { value: model[modelType] }
-								: model[modelType],
+								: // Only send a JSON valid version of the model or it will be rejected
+									JSON.parse(
+										JSON.stringify(model[modelType], stringifyIgnoreValidator),
+									),
 						model_type: modelType,
 					};
 					const id = result?.[0]?.id;
@@ -1349,8 +1357,17 @@ const runODataRequest = (req: Express.Request, vocabulary: string) => {
 							})
 						: resolveSynonym($request);
 
-					if (abstractSqlModel.tables[resolvedResourceName] == null) {
+					const table = abstractSqlModel.tables[resolvedResourceName];
+					if (table == null) {
 						throw new UnauthorizedError();
+					}
+
+					// TODO: probably need special canAccess handling.. atm it works because we use `looseObject`
+					const validator = validation.getValidator(table);
+					try {
+						parsedRequest.values = validator.parse(parsedRequest.values);
+					} catch {
+						throw new BadRequestError();
 					}
 
 					$request.hooks = [];

--- a/src/sbvr-api/validation.ts
+++ b/src/sbvr-api/validation.ts
@@ -1,0 +1,45 @@
+import type {
+	AbstractSqlModel,
+	AbstractSqlTable,
+} from '@balena/abstract-sql-compiler';
+import { sqlNameToODataName } from '@balena/odata-to-abstract-sql';
+import z from 'zod';
+import $sbvrTypes from '@balena/sbvr-types';
+const { default: sbvrTypes } = $sbvrTypes;
+
+// Augment express.js with pinejs-specific attributes via declaration merging.
+declare module '@balena/abstract-sql-compiler' {
+	export interface AbstractSqlTable {
+		validator?: z.ZodObject;
+	}
+}
+
+export const getValidator = (table: AbstractSqlTable) => {
+	if (table.validator == null) {
+		const zObject: Record<string, z.ZodType> = {};
+		for (const { fieldName, dataType, required } of table.fields) {
+			zObject[sqlNameToODataName(fieldName)] =
+				sbvrTypes[dataType as keyof typeof sbvrTypes].schema[
+					required ? 'optional' : 'nullish'
+				]();
+		}
+		table.validator = z.looseObject(zObject);
+	}
+	return table.validator;
+};
+
+export const prepareModel = (abstractSqlModel: AbstractSqlModel) => {
+	for (const table of Object.values(abstractSqlModel.tables)) {
+		getValidator(table);
+	}
+};
+
+/**
+ * The validator we add to the AbstractSqlTable is a ZodObject, which is not serializable to JSON. This function is used to ignore these validators whilst stringifying, allowing it to work.
+ */
+export const stringifyIgnoreValidator = (key: string, value: any) => {
+	if (key === 'validator' && value instanceof z.ZodObject) {
+		return undefined;
+	}
+	return value;
+};

--- a/src/server-glue/module.ts
+++ b/src/server-glue/module.ts
@@ -1,6 +1,8 @@
 import type Express from 'express';
 
 import './sbvr-loader.js';
+// Necessary for interface merging to work properly for adding the `validator` property to `AbstractSqlTable`
+import '../sbvr-api/validation.js';
 
 import * as dbModule from '../database-layer/db.js';
 import * as configLoader from '../config-loader/config-loader.js';

--- a/test/01-constrain.test.ts
+++ b/test/01-constrain.test.ts
@@ -80,7 +80,7 @@ describe('01 basic constrain tests', function () {
 				.send({
 					name: null,
 				})
-				.expect(400, '"\\"name\\" cannot be null"');
+				.expect(400);
 		});
 
 		it('should return 400 when filter uses an undefined named parameter', async () => {


### PR DESCRIPTION
This means hooks will receive validated data that they can trust to be of the expected type and improve the developer experience along with safety

https://balena.fibery.io/Work/Project/1002

Change-type: minor